### PR TITLE
Add interactive input TCP channel

### DIFF
--- a/agents/matlab/README.md
+++ b/agents/matlab/README.md
@@ -184,6 +184,8 @@ logging:
 tcp:
   host: localhost # The hostname or IP address for TCP communication.
   port: 5678 # The port number for TCP communication.
+  input_host: localhost # Hostname for the input TCP channel.
+  input_port: 5679 # Port for the input TCP channel.
 
 response_templates:
   success:

--- a/agents/matlab/matlab_agent/config/config.yaml.template
+++ b/agents/matlab/matlab_agent/config/config.yaml.template
@@ -33,6 +33,8 @@ performance:
 tcp:
   host: localhost
   port: 5678
+  input_host: localhost
+  input_port: 5679
 
 response_templates:
   success:

--- a/agents/matlab/matlab_agent/docs/examples/interactive-simulation/InteractiveSimulation.m
+++ b/agents/matlab/matlab_agent/docs/examples/interactive-simulation/InteractiveSimulation.m
@@ -4,7 +4,7 @@ function InteractiveSimulation()
     disp("🟢 Starting communication loop...");
     while true
         % Receive data from Python (blocking at start, then streaming)
-        data_in = wrapper.get_inputs();
+        data_in = wrapper.get_input();
 
         if ~isempty(data_in)
             disp("📥 Input received:");

--- a/agents/matlab/matlab_agent/docs/examples/interactive-simulation/SimulationWrapper.m
+++ b/agents/matlab/matlab_agent/docs/examples/interactive-simulation/SimulationWrapper.m
@@ -1,15 +1,17 @@
 classdef SimulationWrapper < handle
     properties (Access = private)
-        tcp_client  % TCP client object for communication with Python
+        out_client  % TCP client object for outgoing data
+        in_client   % TCP client object for incoming data
         last_inputs % Store the last inputs received from Python
     end
     
     methods
         % Constructor for the SimulationWrapper class
         function obj = SimulationWrapper()
-            % Default host and port (modifiable)
+            % Default host and ports (modifiable)
             host = 'localhost';
-            port = 5678;
+            out_port = 5678;
+            in_port = 5679;
             % Max retries for connecting to the server
             max_retries = 5;
             retry_delay = 1;  % Delay between retries in seconds
@@ -18,9 +20,10 @@ classdef SimulationWrapper < handle
             for retry = 1:max_retries
                 try
                     % Create a TCP client object to connect to Python server
-                    obj.tcp_client = tcpclient(host, port);
-                    % Configure the TCP client to use LF as a terminator
-                    configureTerminator(obj.tcp_client, "LF");
+                    obj.out_client = tcpclient(host, out_port);
+                    obj.in_client = tcpclient(host, in_port);
+                    configureTerminator(obj.out_client, "LF");
+                    configureTerminator(obj.in_client, "LF");
                     break; % Exit the loop if the connection is successful
                 catch ME
                     % If connection fails, retry up to 'max_retries' times
@@ -34,7 +37,7 @@ classdef SimulationWrapper < handle
             end
 
             % Receive the initial parameters in JSON format from Python
-            data = readline(obj.tcp_client);
+            data = readline(obj.out_client);
             % Decode the received JSON data and store it as 'last_inputs'
             obj.last_inputs = jsondecode(data);
         end
@@ -42,8 +45,8 @@ classdef SimulationWrapper < handle
         function data_struct = try_receive(obj)
             % Non-blocking receive function to get data if available
             data_struct = [];
-            while obj.tcp_client.NumBytesAvailable > 0
-                line = readline(obj.tcp_client);
+            while obj.in_client.NumBytesAvailable > 0
+                line = readline(obj.in_client);
                 disp("📩 Received:");
                 disp(line)
                 try
@@ -55,7 +58,7 @@ classdef SimulationWrapper < handle
         end
         
         % Method to retrieve input parameters from the Python server
-        function inputs = get_inputs(obj)
+        function inputs = get_input(obj)
             % Single method to get input data
             % Reads new streaming data if available, otherwise returns last input
 
@@ -71,13 +74,14 @@ classdef SimulationWrapper < handle
             % Convert the output data to JSON format
             json_data = jsonencode(output_data);
             % Send the JSON-encoded data to Python server
-            writeline(obj.tcp_client, json_data);
+            writeline(obj.out_client, json_data);
         end
 
         % Destructor to clean up the TCP client object when the wrapper is deleted
         function delete(obj)
             % Close the TCP connection by deleting the client object
-            delete(obj.tcp_client);
+            delete(obj.out_client);
+            delete(obj.in_client);
         end
     end
 end

--- a/agents/matlab/matlab_agent/src/comm/rabbitmq/message_handler.py
+++ b/agents/matlab/matlab_agent/src/comm/rabbitmq/message_handler.py
@@ -282,7 +282,7 @@ class MessageHandler(IRabbitMQMessageHandler):
         from functools import partial
 
         # Pass the actual Queue object, not the string
-        callback_with_tcp = partial(handle_interactive_input, tcp_settings=tcp_settings, input_queue=input_queue)
+        callback_with_tcp = partial(handle_interactive_input, input_queue=input_queue)
 
         self.rabbitmq_manager.channel.basic_consume(
             queue=queue_name,

--- a/agents/matlab/matlab_agent/src/core/interactive.py
+++ b/agents/matlab/matlab_agent/src/core/interactive.py
@@ -21,7 +21,7 @@ from ..utils.performance_monitor import PerformanceMonitor
 logger = get_logger()
 
 
-def handle_interactive_input(ch, method, properties, body, tcp_settings: Dict[str, Any], input_queue: Queue) -> None:
+def handle_interactive_input(ch, method, properties, body, input_queue: Queue) -> None:
     """Handle incoming interactive input messages and put them in the queue"""
     try:
         msg = yaml.safe_load(body)
@@ -81,7 +81,7 @@ def handle_interactive_simulation(
             agent_id = agent_id
         )
         controller.start(performance_monitor)
-        controller.run(data.get('inputs', {}), performance_monitor, msg_dict, tcp_settings, request_id)
+        controller.run(data.get('inputs', {}), performance_monitor, msg_dict, request_id)
         performance_monitor.record_matlab_stop()
 
         success_response = create_response(
@@ -197,7 +197,10 @@ class MatlabInteractiveController:
         self.response_templates: Dict = response_templates
         host = tcp_settings.get('host', 'localhost')
         port = tcp_settings.get('port', 5678)
+        in_host = tcp_settings.get('input_host', host)
+        in_port = tcp_settings.get('input_port', 5679)
         self.connection = InteractiveConnection(host, port)
+        self.input_connection = InteractiveConnection(in_host, in_port)
         self.rabbitmq_manager = message_broker
         if not self.sim_path.exists() or not (self.sim_path / self.sim_file).exists():
             raise FileNotFoundError(f"Simulation file '{self.sim_file}' not found in '{self.sim_path}'")
@@ -229,8 +232,8 @@ class MatlabInteractiveController:
     def start(self, performance_monitor: PerformanceMonitor) -> None:
         try:
             self.start_time = time.time()
-            ## here you want to start the TCP server and MATLAB process
-            # self.connection.start_server()
+            self.connection.start_server()
+            self.input_connection.start_server()
             self._start_matlab()
             performance_monitor.record_matlab_startup_complete()
             logger.debug("MATLAB startup duration: %.2fs", time.time() - self.start_time)
@@ -268,11 +271,8 @@ class MatlabInteractiveController:
             time.sleep(delay)
 
 
-    def run(self, inputs: Dict[str, Any], performance_monitor,  msg_dict, tcp_settings, request_id) -> None:
+    def run(self, inputs: Dict[str, Any], performance_monitor, msg_dict, request_id) -> None:
         """Run the interactive simulation with proper Queue handling"""
-        tcp = TCPClient()
-        tcp.connect()
-
         input_queue = Queue()
         simulation_data = msg_dict.get('simulation', {})        
         stream_key = simulation_data.get("inputs", {}).get("stream_source", "").replace("rabbitmq://", "")
@@ -297,7 +297,7 @@ class MatlabInteractiveController:
         from functools import partial
 
         # Pass the actual Queue object, not the string
-        callback_with_tcp = partial(handle_interactive_input, tcp_settings=tcp_settings, input_queue=input_queue)
+        callback_with_tcp = partial(handle_interactive_input, input_queue=input_queue)
 
         self.rabbitmq_manager.channel.basic_consume(
             queue=queue_name,
@@ -311,12 +311,14 @@ class MatlabInteractiveController:
         try:
             logger.debug("Waiting for MATLAB connection...")
             self.connection.accept_connection()
+            self.input_connection.accept_connection()
             self.connection.send(inputs)
+            sequence = 0
 
             while True:
                 try:
                     command = input_queue.get(timeout=100)
-                    self.connection.send(command)
+                    self.input_connection.send(command)
                     responses = self.connection.receive()
                     for response in responses:
                         self._process_output(response, sequence)

--- a/agents/matlab/matlab_agent/src/utils/config_manager.py
+++ b/agents/matlab/matlab_agent/src/utils/config_manager.py
@@ -60,6 +60,8 @@ class Config(BaseModel):
     # TCP configuration
     tcp_host: str = Field(default="localhost")
     tcp_port: int = Field(default=5678)
+    tcp_input_host: str = Field(default="localhost")
+    tcp_input_port: int = Field(default=5679)
 
     # Response templates
     # Success template
@@ -127,7 +129,9 @@ class Config(BaseModel):
             },
             "tcp": {
                 "host": self.tcp_host,
-                "port": self.tcp_port
+                "port": self.tcp_port,
+                "input_host": self.tcp_input_host,
+                "input_port": self.tcp_input_port
             },
             "response_templates": {
                 "success": {
@@ -212,6 +216,8 @@ class Config(BaseModel):
         if tcp := config_dict.get("tcp", {}):
             flat_config["tcp_host"] = tcp.get("host", "localhost")
             flat_config["tcp_port"] = tcp.get("port", 5678)
+            flat_config["tcp_input_host"] = tcp.get("input_host", "localhost")
+            flat_config["tcp_input_port"] = tcp.get("input_port", 5679)
 
         # Extract response_templates section if present
         if templates := config_dict.get("response_templates", {}):

--- a/agents/matlab/matlab_agent/tests/integration/test_interactive_input_channel.py
+++ b/agents/matlab/matlab_agent/tests/integration/test_interactive_input_channel.py
@@ -1,0 +1,38 @@
+import yaml
+from queue import Queue
+from unittest.mock import MagicMock
+
+from src.core.interactive import handle_interactive_input, MatlabInteractiveController
+
+
+def test_handle_interactive_input_forwards_to_queue():
+    q = Queue()
+    body = yaml.dump({'simulation': {'inputs': {'a': 1}}}).encode()
+    handle_interactive_input(None, None, None, body, q)
+    assert not q.empty()
+    assert q.get()['simulation']['inputs']['a'] == 1
+
+def test_run_sends_queue_messages(monkeypatch):
+    mq = MagicMock()
+    mq.channel = MagicMock()
+    mq.channel.exchange_declare.return_value = None
+    mq.channel.queue_declare.return_value = None
+    mq.channel.queue_bind.return_value = None
+    mq.channel.basic_consume.side_effect = lambda **kwargs: None
+    controller = MatlabInteractiveController(
+        '.', 'file.m', 'src', mq, {},
+        {'host': 'localhost', 'port': 5000, 'input_host': 'localhost', 'input_port': 5001},
+        'meta', 'req', 'agent'
+    )
+    controller.connection = MagicMock()
+    controller.input_connection = MagicMock()
+    controller.connection.receive.return_value = []
+    controller.connection.accept_connection = MagicMock()
+    controller.input_connection.accept_connection = MagicMock()
+    monkeypatch.setattr('src.core.interactive.Queue', Queue)
+    q = Queue()
+    handle_interactive_input(None, None, None, yaml.dump({'val': 1}).encode(), q)
+    controller.command_producer = lambda q, delay=0.5: None
+    monkeypatch.setattr('src.core.interactive.Queue', lambda: q)
+    controller.run({}, MagicMock(), {'simulation': {'inputs': {'stream_source': ''}}}, 'req')
+    controller.input_connection.send.assert_called()

--- a/agents/matlab/matlab_agent/tests/unit/test_config_manager.py
+++ b/agents/matlab/matlab_agent/tests/unit/test_config_manager.py
@@ -36,7 +36,9 @@ def mock_config_data():
         },
         "tcp": {
             "host": "localhost",
-            "port": 5678
+            "port": 5678,
+            "input_host": "localhost",
+            "input_port": 5679
         },
         "response_templates": {
             "success": {
@@ -139,7 +141,9 @@ def test_config_manager_initialization():
         },
         "tcp": {
             "host": "localhost",
-            "port": 5678
+            "port": 5678,
+            "input_host": "localhost",
+            "input_port": 5679
         },
         "response_templates": {
             "success": {


### PR DESCRIPTION
## Summary
- extend MATLAB agent config with `tcp.input_host` and `tcp.input_port`
- enable second TCP server in `MatlabInteractiveController`
- update interactive MATLAB wrapper to use separate input/output sockets
- document new TCP input settings
- add tests for interactive input handler

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686546ea85e08333bf4984f1e6db5c98