### PR TITLE
Enable in-memory protocol configuration

### DIFF
--- a/simulation_bridge/config/config.yaml.template
+++ b/simulation_bridge/config/config.yaml.template
@@ -1,5 +1,6 @@
 simulation_bridge:
   bridge_id: simulation_bridge
+  in_memory_mode: false
 
 rabbitmq:
   host: localhost

--- a/simulation_bridge/src/core/bridge_orchestrator.py
+++ b/simulation_bridge/src/core/bridge_orchestrator.py
@@ -41,7 +41,8 @@ class BridgeOrchestrator:
         self.adapters = {}
         self._running = False
 
-        self.protocol_config = load_protocol_config()
+        self.protocol_config = load_protocol_config(self.config_manager.config_path)
+        SignalManager.PROTOCOL_CONFIG = self.protocol_config
         self.adapter_classes = self._import_adapter_classes()
 
     def setup_interfaces(self):

--- a/simulation_bridge/src/protocol_adapters/inmemory/inmemory_adapter.py
+++ b/simulation_bridge/src/protocol_adapters/inmemory/inmemory_adapter.py
@@ -84,41 +84,6 @@ class InMemoryAdapter(ProtocolAdapter):
         pass
 
 
-class DummyAdapter(ProtocolAdapter):
-    """Neutral adapter for MQTT and REST protocols."""
-
-    def __init__(self, config_manager: ConfigManager | None = None):
-        super().__init__(config_manager or ConfigManager(None))
-
-    def _get_config(self) -> Dict[str, Any]:
-        return {}
-
-    def start(self) -> None:
-        logger.debug("DummyAdapter started (no-op)")
-        self._running = True
-
-    def stop(self) -> None:
-        logger.debug("DummyAdapter stopped (no-op)")
-        self._running = False
-
-    def _handle_message(self, message: Dict[str, Any]) -> None:  # noqa: D401
-        # This method is intentionally empty as DummyAdapter serves as a null object
-        # to prevent errors when MQTT/REST protocols are not used but signals expect
-        # these adapters to be registered
-        pass
-
-    def publish_result_message_mqtt(self, *_, **__) -> None:
-        # This method is intentionally empty as DummyAdapter serves as a null object
-        # to prevent errors when MQTT/REST protocols are not used but signals expect
-        # these adapters to be registered
-        pass
-
-    def publish_result_message_rest(self, *_, **__) -> None:
-        # This method is intentionally empty as DummyAdapter serves as a null object
-        # to prevent errors when MQTT/REST protocols are not used but signals expect
-        # these adapters to be registered
-        pass
-
 
 class SimulationBridge:
     """Run simulations using the in-memory protocol adapter."""
@@ -139,12 +104,6 @@ class SimulationBridge:
             "inmemory", self.inmemory_adapter)
         SignalManager.register_adapter_instance(
             "rabbitmq", self.rabbitmq_adapter)
-
-        # Required to satisfy signals expecting these adapters.
-        # Acts as a "null object" to avoid errors when MQTT/REST are unused.
-        dummy = DummyAdapter()
-        SignalManager.register_adapter_instance("mqtt", dummy)
-        SignalManager.register_adapter_instance("rest", dummy)
 
         SignalManager.connect_all_signals()
 

--- a/simulation_bridge/src/protocol_adapters/inmemory/inmemory_adapter.py
+++ b/simulation_bridge/src/protocol_adapters/inmemory/inmemory_adapter.py
@@ -7,6 +7,7 @@ from ...utils.config_manager import ConfigManager
 from ...utils.logger import get_logger
 from ..base.protocol_adapter import ProtocolAdapter
 from ...utils.signal_manager import SignalManager
+from ...utils.config_loader import load_protocol_config
 from ...core.bridge_core import BridgeCore
 from ..rabbitmq.rabbitmq_adapter import RabbitMQAdapter
 
@@ -90,6 +91,8 @@ class SimulationBridge:
 
     def __init__(self, config_path: str | None = None) -> None:
         self.config_manager = ConfigManager(config_path)
+        SignalManager.PROTOCOL_CONFIG = load_protocol_config(
+            self.config_manager.config_path)
         self.inmemory_adapter = InMemoryAdapter(self.config_manager)
         self.rabbitmq_adapter = RabbitMQAdapter(self.config_manager)
 

--- a/simulation_bridge/src/protocol_adapters/inmemory_signal.json
+++ b/simulation_bridge/src/protocol_adapters/inmemory_signal.json
@@ -1,0 +1,21 @@
+{
+  "protocols": {
+    "rabbitmq": {
+      "enabled": true,
+      "signals": {
+        "message_received_input_rabbitmq": "BridgeCore.handle_input_message",
+        "message_received_result_rabbitmq": "BridgeCore.handle_result_rabbitmq_message",
+        "message_received_result_unknown": "BridgeCore.handle_result_unknown_message"
+      },
+      "class": ".rabbitmq.rabbitmq_adapter.RabbitMQAdapter"
+    },
+    "inmemory": {
+      "enabled": true,
+      "signals": {
+        "message_received_input_inmemory": "BridgeCore.handle_input_message",
+        "message_received_result_inmemory": "InMemoryAdapter._handle_result"
+      },
+      "class": ".inmemory.inmemory_adapter.InMemoryAdapter"
+    }
+  }
+}

--- a/simulation_bridge/src/utils/config_loader.py
+++ b/simulation_bridge/src/utils/config_loader.py
@@ -88,11 +88,22 @@ def _substitute_env_vars(
     return config
 
 
-def load_protocol_config() -> Dict[str, list]:
+def load_protocol_config(config_path: Optional[Union[str, Path]] = None) -> Dict[str, list]:
+    """Load the protocol configuration based on in-memory mode.
+
+    If the provided configuration file (or the default one) contains
+    ``in_memory_mode: true`` under ``simulation_bridge``, the reduced
+    ``inmemory_signal.json`` file will be loaded instead of the full
+    ``adapters_signal.json``.
     """
-    Load the protocol configuration from a JSON file.
-    """
-    config_file = Path(__file__).parent.parent / \
-        "protocol_adapters/adapters_signal.json"
-    with open(config_file, 'r', encoding='utf-8') as f:
+    cfg_path = Path(config_path) if config_path else Path(__file__).parent.parent.parent.parent / "config.yaml"
+    in_memory = False
+    try:
+        cfg = load_config(str(cfg_path))
+        in_memory = cfg.get("simulation_bridge", {}).get("in_memory_mode", False)
+    except Exception:  # noqa: BLE001
+        logger.debug("Configuration not found or invalid, using defaults")
+    json_name = "inmemory_signal.json" if in_memory else "adapters_signal.json"
+    config_file = Path(__file__).parent.parent / f"protocol_adapters/{json_name}"
+    with open(config_file, "r", encoding="utf-8") as f:
         return json.load(f)["protocols"]

--- a/simulation_bridge/src/utils/config_manager.py
+++ b/simulation_bridge/src/utils/config_manager.py
@@ -113,6 +113,7 @@ class PerformanceConfig(BaseModel):
 class SimulationBridgeConfig(BaseModel):
     """Configuration for simulation bridge."""
     bridge_id: str
+    in_memory_mode: bool = False
 
 
 class Config(BaseModel):
@@ -237,7 +238,8 @@ class ConfigManager:
         """Get default configuration as dictionary."""
         return Config(
             simulation_bridge=SimulationBridgeConfig(
-                bridge_id="simulation_bridge"),
+                bridge_id="simulation_bridge",
+                in_memory_mode=False),
             rabbitmq=RabbitMQConfig(
                 host="localhost",
                 port=5672,

--- a/simulation_bridge/test/integration/test_integration.py
+++ b/simulation_bridge/test/integration/test_integration.py
@@ -323,7 +323,7 @@ def test_bridge_orchestrator_init_calls_ensure_certificates(monkeypatch):
         MagicMock())
     monkeypatch.setattr(
         "simulation_bridge.src.core.bridge_orchestrator.load_protocol_config",
-        lambda: {})
+        lambda *a, **k: {})
     monkeypatch.setattr(
         "simulation_bridge.src.core.bridge_orchestrator.BridgeOrchestrator._import_adapter_classes",
         lambda self: {})
@@ -344,7 +344,7 @@ def test_bridge_orchestrator_init_ensure_certificates_exception(monkeypatch):
         MagicMock())
     monkeypatch.setattr(
         "simulation_bridge.src.core.bridge_orchestrator.load_protocol_config",
-        lambda: {})
+        lambda *a, **k: {})
     monkeypatch.setattr(
         "simulation_bridge.src.core.bridge_orchestrator.BridgeOrchestrator._import_adapter_classes",
         lambda self: {})
@@ -367,7 +367,7 @@ def test_bridge_orchestrator_init_certificates_custom_days(monkeypatch):
         MagicMock())
     monkeypatch.setattr(
         "simulation_bridge.src.core.bridge_orchestrator.load_protocol_config",
-        lambda: {})
+        lambda *a, **k: {})
     monkeypatch.setattr(
         "simulation_bridge.src.core.bridge_orchestrator.BridgeOrchestrator._import_adapter_classes",
         lambda self: {})
@@ -385,7 +385,7 @@ def test_bridge_orchestrator_start_and_stop(monkeypatch, mock_config_manager):
         lambda *a, **k: mock_config_manager)
     monkeypatch.setattr(
         "simulation_bridge.src.core.bridge_orchestrator.load_protocol_config",
-        lambda: {})
+        lambda *a, **k: {})
     monkeypatch.setattr(
         "simulation_bridge.src.core.bridge_orchestrator.BridgeOrchestrator._import_adapter_classes",
         lambda self: {})
@@ -412,7 +412,7 @@ def test_bridge_orchestrator_logs_bridge_id(monkeypatch, caplog):
                 'rabbitmq': {}}))
     monkeypatch.setattr(
         "simulation_bridge.src.core.bridge_orchestrator.load_protocol_config",
-        lambda: {})
+        lambda *a, **k: {})
     monkeypatch.setattr(
         "simulation_bridge.src.core.bridge_orchestrator.BridgeOrchestrator._import_adapter_classes",
         lambda self: {})
@@ -507,7 +507,7 @@ def test_bridge_orchestrator_logs_error_on_exception(monkeypatch, caplog):
                 'rabbitmq': {}}))
     monkeypatch.setattr(
         "simulation_bridge.src.core.bridge_orchestrator.load_protocol_config",
-        lambda: {})
+        lambda *a, **k: {})
     monkeypatch.setattr(
         "simulation_bridge.src.core.bridge_orchestrator.BridgeOrchestrator._import_adapter_classes",
         lambda self: {})
@@ -550,7 +550,7 @@ def test_bridge_orchestrator_certificates_validation_valid(
                 'rabbitmq': {}}))
     monkeypatch.setattr(
         "simulation_bridge.src.core.bridge_orchestrator.load_protocol_config",
-        lambda: {})
+        lambda *a, **k: {})
     monkeypatch.setattr(
         "simulation_bridge.src.core.bridge_orchestrator.BridgeOrchestrator._import_adapter_classes",
         lambda self: {})
@@ -622,7 +622,7 @@ def test_bridge_orchestrator_certificates_validation_expired(
                 'rabbitmq': {}}))
     monkeypatch.setattr(
         "simulation_bridge.src.core.bridge_orchestrator.load_protocol_config",
-        lambda: {})
+        lambda *a, **k: {})
     monkeypatch.setattr(
         "simulation_bridge.src.core.bridge_orchestrator.BridgeOrchestrator._import_adapter_classes",
         lambda self: {})
@@ -657,7 +657,7 @@ def test_bridge_orchestrator_certificates_missing_files(
                 'rabbitmq': {}}))
     monkeypatch.setattr(
         "simulation_bridge.src.core.bridge_orchestrator.load_protocol_config",
-        lambda: {})
+        lambda *a, **k: {})
     monkeypatch.setattr(
         "simulation_bridge.src.core.bridge_orchestrator.BridgeOrchestrator._import_adapter_classes",
         lambda self: {})
@@ -698,7 +698,7 @@ def test_bridge_orchestrator_certificates_corrupted_files(
                 'rabbitmq': {}}))
     monkeypatch.setattr(
         "simulation_bridge.src.core.bridge_orchestrator.load_protocol_config",
-        lambda: {})
+        lambda *a, **k: {})
     monkeypatch.setattr(
         "simulation_bridge.src.core.bridge_orchestrator.BridgeOrchestrator._import_adapter_classes",
         lambda self: {})
@@ -729,7 +729,7 @@ def test_bridge_orchestrator_certificates_permission_error(
                 'rabbitmq': {}}))
     monkeypatch.setattr(
         "simulation_bridge.src.core.bridge_orchestrator.load_protocol_config",
-        lambda: {})
+        lambda *a, **k: {})
     monkeypatch.setattr(
         "simulation_bridge.src.core.bridge_orchestrator.BridgeOrchestrator._import_adapter_classes",
         lambda self: {})


### PR DESCRIPTION
## Summary
- add `in_memory_mode` option to config template
- switch protocol loading based on this flag
- provide minimal `inmemory_signal.json` file
- update bridge orchestrator to apply selected protocol config
- simplify in-memory adapter and drop dummy protocols
- adjust tests for new function signature

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'blinker')*

------
https://chatgpt.com/codex/tasks/task_e_6877b1c280c48333a774f7533f79d7d7