### PR TITLE
Implement simulation thread management

### DIFF
--- a/agents/matlab/matlab_agent/src/comm/connect.py
+++ b/agents/matlab/matlab_agent/src/comm/connect.py
@@ -160,6 +160,13 @@ class Connect:
             return self.broker.send_result(destination, result)
         raise RuntimeError(BROKER_NOT_INITIALIZED_ERROR)
 
+    def send_result_threadsafe(self, destination: str, result: Dict[str, Any]) -> None:
+        """Thread-safe variant of :meth:`send_result`."""
+        if self.broker:
+            self.broker.send_result_threadsafe(destination, result)
+            return
+        raise RuntimeError(BROKER_NOT_INITIALIZED_ERROR)
+
     def close(self) -> None:
         """
         Close the connection to the message broker.

--- a/agents/matlab/matlab_agent/src/comm/interfaces.py
+++ b/agents/matlab/matlab_agent/src/comm/interfaces.py
@@ -62,6 +62,15 @@ class IMessageBroker(ABC):
         """
 
     @abstractmethod
+    def send_message_threadsafe(
+            self,
+            exchange: str,
+            routing_key: str,
+            body: Any,
+            properties: Optional[Any] = None) -> None:
+        """Schedule :meth:`send_message` to run in the broker thread."""
+
+    @abstractmethod
     def send_result(self, destination: str, result: Dict[str, Any]) -> bool:
         """
         Send operation results to the specified destination.
@@ -73,6 +82,10 @@ class IMessageBroker(ABC):
         Returns:
             bool: True if successful, False otherwise
         """
+
+    @abstractmethod
+    def send_result_threadsafe(self, destination: str, result: Dict[str, Any]) -> None:
+        """Schedule :meth:`send_result` to run in the broker thread."""
 
     @abstractmethod
     def close(self) -> None:

--- a/agents/matlab/matlab_agent/src/comm/rabbitmq/message_handler.py
+++ b/agents/matlab/matlab_agent/src/comm/rabbitmq/message_handler.py
@@ -2,6 +2,7 @@
 Message handler for processing incoming RabbitMQ messages.
 """
 import uuid
+import threading
 from typing import Any, Optional, Dict
 
 import yaml
@@ -99,6 +100,8 @@ class MessageHandler(IRabbitMQMessageHandler):
         self.response_templates = self.config.get(
             'response_templates', {})
         self.interactive_queues: Dict[str, queue.Queue] = {}
+        self._sim_thread: Optional[threading.Thread] = None
+        self._lock = threading.Lock()
 
     def get_agent_id(self) -> str:
         """
@@ -144,9 +147,11 @@ class MessageHandler(IRabbitMQMessageHandler):
                 if isinstance(msg_dict, dict) and 'command' in msg_dict:
                     cmd = msg_dict['command'].upper()
                     if cmd == 'STOP':
-                        # Signal to stop the current simulation
-                        logger.info("Received STOP command, signaling to stop simulation")
+                        logger.info("Received STOP command, terminating simulation thread")
                         CommandRegistry.stop()
+                        with self._lock:
+                            if self._sim_thread and self._sim_thread.is_alive():
+                                self._sim_thread.join(timeout=1)
                     elif cmd == 'RUN':
                         # Reset the stop event to allow running simulations
                         logger.info("Received RUN command, resetting stop event")
@@ -236,52 +241,74 @@ class MessageHandler(IRabbitMQMessageHandler):
                 ch.basic_nack(delivery_tag=method.delivery_tag, requeue=False)
                 return
             logger.info("Received simulation type: %s", sim_type)
-            # Process based on simulation type
-            if sim_type == 'batch':
-                handle_batch_simulation(
-                    msg_dict,
-                    source,
-                    self.rabbitmq_manager,
-                    self.path_simulation,
-                    self.response_templates)
-                ch.basic_ack(delivery_tag=method.delivery_tag)
-            elif sim_type == 'streaming':
-                ch.basic_ack(delivery_tag=method.delivery_tag)
-                tcp_settings = self.config.get(
-                    'tcp', {})
-                handle_streaming_simulation(
-                    msg_dict, source,
-                    self.rabbitmq_manager,
-                    self.path_simulation,
-                    self.response_templates,
-                    tcp_settings
+            # Stop any running simulation thread before starting a new one
+            with self._lock:
+                if self._sim_thread and self._sim_thread.is_alive():
+                    CommandRegistry.stop()
+                    self._sim_thread.join(timeout=1)
+                    CommandRegistry.reset()
+
+                if sim_type == 'batch':
+                    target = handle_batch_simulation
+                    args = (
+                        msg_dict,
+                        source,
+                        self.rabbitmq_manager,
+                        self.path_simulation,
+                        self.response_templates
+                    )
+                elif sim_type == 'streaming':
+                    tcp_settings = self.config.get('tcp', {})
+                    target = handle_streaming_simulation
+                    args = (
+                        msg_dict,
+                        source,
+                        self.rabbitmq_manager,
+                        self.path_simulation,
+                        self.response_templates,
+                        tcp_settings,
+                    )
+                elif sim_type == 'interactive':
+                    tcp_settings = self.config.get('tcp', {})
+                    target = handle_interactive_simulation
+                    args = (
+                        msg_dict,
+                        source,
+                        self.rabbitmq_manager,
+                        self.path_simulation,
+                        self.response_templates,
+                        tcp_settings,
+                    )
+                else:
+                    target = None
+                    args = None
+
+                if target is None:
+                    logger.error("Unknown simulation type: %s", sim_type)
+                    error_response = create_response(
+                        template_type='error',
+                        sim_file=sim_file,
+                        sim_type=sim_type,
+                        response_templates={},
+                        bridge_meta=bridge_meta,
+                        request_id=request_id,
+                        error={
+                            'message': f'Unknown simulation type: {sim_type}',
+                            'type': 'invalid_simulation_type'
+                        }
+                    )
+                    self.rabbitmq_manager.send_result(source, error_response)
+                    ch.basic_nack(delivery_tag=method.delivery_tag, requeue=False)
+                    return
+
+                # Start new simulation thread
+                self._sim_thread = threading.Thread(
+                    target=target,
+                    args=args,
+                    daemon=True
                 )
-            elif sim_type == 'interactive':
+                self._sim_thread.start()
                 ch.basic_ack(delivery_tag=method.delivery_tag)
-                tcp_settings = self.config.get('tcp', {})
-                handle_interactive_simulation(
-                    msg_dict, source,
-                    self.rabbitmq_manager,
-                    self.path_simulation,
-                    self.response_templates,
-                    tcp_settings
-                )
-            else:
-                logger.error("Unknown simulation type: %s", sim_type)
-                error_response = create_response(
-                    template_type='error',
-                    sim_file=sim_file,
-                    sim_type=sim_type,
-                    response_templates={},
-                    bridge_meta=bridge_meta,
-                    request_id=request_id,
-                    error={
-                        'message': f'Unknown simulation type: {sim_type}',
-                        'type': 'invalid_simulation_type'
-                    }
-                )
-                self.rabbitmq_manager.send_result(source, error_response)
-                ch.basic_nack(delivery_tag=method.delivery_tag, requeue=False)
 
         except Exception as e:
             logger.error("Error processing message %s: %s", message_id, e)

--- a/agents/matlab/matlab_agent/src/comm/rabbitmq/rabbitmq_manager.py
+++ b/agents/matlab/matlab_agent/src/comm/rabbitmq/rabbitmq_manager.py
@@ -264,6 +264,26 @@ class RabbitMQManager(IRabbitMQManager):
             logger.error("Unexpected error: %s", e)
             return False
 
+    def send_message_threadsafe(
+        self,
+        exchange: str,
+        routing_key: str,
+        body: str,
+        properties: Optional[BasicProperties] = None,
+    ) -> None:
+        """Schedule *send_message* to run in the connection thread."""
+        if not self.connection:
+            logger.error("Connection not available for async publish")
+            return
+
+        def _publish() -> None:
+            self.send_message(exchange, routing_key, body, properties)
+
+        try:
+            self.connection.add_callback_threadsafe(_publish)
+        except Exception as exc:  # pragma: no cover - unexpected errors
+            logger.error("Failed to schedule async publish: %s", exc)
+
     def send_result(self, destination: str, result: Dict[str, Any]) -> bool:
         """
         Send simulation results to the specified destination.
@@ -313,6 +333,20 @@ class RabbitMQManager(IRabbitMQManager):
             logger.error("Failed to send result to %s", destination)
 
         return success
+
+    def send_result_threadsafe(self, destination: str, result: Dict[str, Any]) -> None:
+        """Schedule :meth:`send_result` to run in the connection thread."""
+        if not self.connection:
+            logger.error("Connection not available for async result")
+            return
+
+        def _publish() -> None:
+            self.send_result(destination, result)
+
+        try:
+            self.connection.add_callback_threadsafe(_publish)
+        except Exception as exc:  # pragma: no cover - unexpected errors
+            logger.error("Failed to schedule async result: %s", exc)
 
     def close(self) -> None:
         """

--- a/agents/matlab/matlab_agent/src/core/agent.py
+++ b/agents/matlab/matlab_agent/src/core/agent.py
@@ -108,3 +108,7 @@ class MatlabAgent:
         if success:
             self.performance_monitor.record_result_sent()
         return success
+
+    def send_result_threadsafe(self, destination: str, result: Dict[str, Any]) -> None:
+        """Thread-safe wrapper around :meth:`send_result`."""
+        self.comm.send_result_threadsafe(destination, result)

--- a/agents/matlab/matlab_agent/src/core/batch.py
+++ b/agents/matlab/matlab_agent/src/core/batch.py
@@ -89,8 +89,8 @@ def handle_batch_simulation(
         )
 
         # Send result and record it
-        if rabbitmq_manager.send_result(source, success_response):
-            performance_monitor.record_result_sent()
+        rabbitmq_manager.send_result_threadsafe(source, success_response)
+        performance_monitor.record_result_sent()
 
         logger.info("Simulation '%s' completed successfully", sim_file)
 
@@ -164,7 +164,7 @@ def _send_progress(
             percentage=percentage,
             bridge_meta=bridge_meta,
             request_id=request_id)
-        broker.send_result(source, progress_response)
+        broker.send_result_threadsafe(source, progress_response)
 
 
 def _get_metadata(sim: MatlabSimulator) -> Dict[str, Any]:
@@ -176,7 +176,7 @@ def _send_response(broker: IMessageBroker, source: str,
                    response: Dict[str, Any]) -> None:
     """Send response through message broker."""
     logger.debug(yaml.dump(response))
-    broker.send_result(source, response)
+    broker.send_result_threadsafe(source, response)
 
 
 def _handle_error(error: Exception,

--- a/agents/matlab/matlab_agent/src/core/interactive.py
+++ b/agents/matlab/matlab_agent/src/core/interactive.py
@@ -206,7 +206,7 @@ class MatlabInteractiveController:
             request_id=self.request_id,
         )
         msg["output"] = payload
-        self.broker.send_result(self.source, msg)
+        self.broker.send_result_threadsafe(self.source, msg)
         self.sequence += 1
 
     @staticmethod
@@ -310,7 +310,7 @@ def handle_interactive_simulation(
         controller.run(pm, msg_dict)
     except (KeyError, ValueError) as exc:  # Handle specific known errors
         logger.error("[INTERACTIVE] Known error: %s", exc)
-        rabbitmq_manager.send_result(
+        rabbitmq_manager.send_result_threadsafe(
             source,
             create_response(
                 "error",
@@ -324,7 +324,7 @@ def handle_interactive_simulation(
         )
     except Exception as exc:  # pragma: no cover - unexpected errors
         logger.exception("[INTERACTIVE] Unexpected error: %s", exc)
-        rabbitmq_manager.send_result(
+        rabbitmq_manager.send_result_threadsafe(
             source,
             create_response(
                 "error",

--- a/agents/matlab/matlab_agent/src/core/streaming.py
+++ b/agents/matlab/matlab_agent/src/core/streaming.py
@@ -105,8 +105,8 @@ def handle_streaming_simulation(
             request_id=request_id,
         )
         # Send result and record it
-        if rabbitmq_manager.send_result(source, success_response):
-            performance_monitor.record_result_sent()
+        rabbitmq_manager.send_result_threadsafe(source, success_response)
+        performance_monitor.record_result_sent()
         logger.info("Completed: %s", sim_file)
 
     except Exception as e:
@@ -120,7 +120,7 @@ def handle_streaming_simulation(
             request_id=request_id,
             error={'message': str(e), 'type': 'execution_error'}
         )
-        rabbitmq_manager.send_result(source, error_response)
+        rabbitmq_manager.send_result_threadsafe(source, error_response)
         raise
     finally:
         # Always complete the operation to record metrics
@@ -250,7 +250,7 @@ class MatlabStreamingController:
             # Record MATLAB startup complete
             performance_monitor.record_matlab_startup_complete()
             logger.debug("MATLAB process started")
-            self.message_broker.send_result(
+            self.message_broker.send_result_threadsafe(
                 self.source,
                 create_response(
                     'success',
@@ -286,7 +286,7 @@ class MatlabStreamingController:
             bridge_meta=self.bridge_meta,
             request_id=self.request_id,
         )
-        self.message_broker.send_result(self.source, response)
+        self.message_broker.send_result_threadsafe(self.source, response)
 
     def run(self, inputs: Dict[str, Any], performance_monitor) -> None:
         """Run simulation and handle streaming data."""
@@ -370,7 +370,7 @@ def _handle_streaming_error(
                  error_type,
                  str(error))
 
-    message_broker.send_result(
+    message_broker.send_result_threadsafe(
         source,
         create_response(
             'error',


### PR DESCRIPTION
## Summary
- manage a single running simulation thread via locking
- stop the running thread when STOP command is received
- start simulations (batch, streaming, interactive) in new threads

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'blinker')*

------
https://chatgpt.com/codex/tasks/task_e_688229b143308333830182e29c71aaf9