### PR TITLE
Update Matlab agent README for new clients

### DIFF
--- a/agents/matlab/matlab_agent/resources/README.md
+++ b/agents/matlab/matlab_agent/resources/README.md
@@ -26,13 +26,15 @@ pip install pika pyyaml
 
 ## Clients
 
-Two Python scripts are provided:
+Three Python scripts are provided, each matching a different simulation mode:
 
-- **use_matlab_agent.py** – Simple client that sends a simulation request and
-  waits for results. Use this for _batch_ and _streaming_ simulations.
-- **use_matlab_agent_interactive.py** – Async client for _interactive_
-  simulations. It streams input frames to MATLAB and prints outputs as they
-  arrive.
+- **use_matlab_agent_batch.py** – Executes a _batch_ simulation and waits until
+  the final results are returned before terminating.
+- **use_matlab_agent_streaming.py** – Starts a _streaming_ simulation where
+  outputs are continuously printed as they arrive.
+- **use_matlab_agent_interactive.py** – Asynchronous client for
+  _interactive_ simulations. It streams input frames to MATLAB and handles
+  real-time results.
 
 ## Configuration
 
@@ -52,6 +54,12 @@ rabbitmq:
 simulation_request: ../api/simulation.yaml # Default path to the simulation YAML payload
 ```
 
+The MATLAB wrapper classes also read their configuration from a
+`config/default.yaml` file. A template named `default.yaml.template` is
+distributed with the agent under `config/`. When you run
+`matlab-agent --generate-project`, this template is copied to
+`config/default.yaml`, which the wrappers use at runtime.
+
 ## Usage
 
 Run the module as a standalone script to send simulation requests to the MATLAB agent and listen asynchronously for the results.
@@ -68,8 +76,9 @@ If this option is omitted, the script will look for a file named `simulation.yam
 - **With CLI option:**
   You can override the default by specifying a custom path to the simulation payload YAML file using the `--api-payload` option.
 
-For interactive simulations, use `use_matlab_agent_interactive.py` with the same
-`--api-payload` flag. This client streams input frames based on the
+For streaming simulations use `use_matlab_agent_streaming.py`. For interactive
+simulations run `use_matlab_agent_interactive.py`; both scripts accept the same
+`--api-payload` flag. The interactive client streams input frames based on the
 `inputs.stream_source` field and prints outputs as they arrive.
 
 ## Example
@@ -91,9 +100,12 @@ you will find several folders containing practical examples. Each example folder
 2. **Run the MATLAB agent**  
    Start the MATLAB agent so it is ready to receive simulation requests.
 
-3. **Send a simulation request using the Python client**  
-    Execute the Python client with the appropriate API payload file:  
-   python use_matlab_agent.py --api-payload "path_to_api_payload"
+3. **Send a simulation request using the Python client**
+    Execute the client that matches your simulation type with the appropriate
+    API payload file:
+   `python use_matlab_agent_batch.py --api-payload "path_to_api_payload"`,
+   `python use_matlab_agent_streaming.py --api-payload "path_to_api_payload"`,
+   or `python use_matlab_agent_interactive.py --api-payload "path_to_api_payload"`.
 
 > **Note:** It is recommended to use absolute paths when specifying the `--api-payload` argument to avoid path resolution issues. It is a good practice to place the path in single quotes.
 


### PR DESCRIPTION
## Summary
- document new Matlab client scripts
- note wrapper config template and generation
- clarify example usage with batch, streaming, and interactive clients

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'blinker')*

------
https://chatgpt.com/codex/tasks/task_e_6883606de7988333a0fe47952d6c064c