### PR TITLE
Add Simulation Bridge AMQP protocol support to emulator

### DIFF
--- a/python-mock-physical-twin/README.md
+++ b/python-mock-physical-twin/README.md
@@ -77,6 +77,9 @@ Details and endpoints related to the RESTful APIs exposed by the implementation 
 collection in the repository folder [api](api). You can import it in PostMan and test the APIs.
 
 ```yaml
+simulation_bridge:
+  client_config: "../simulation_bridge/config/config.yaml" # Path relative to this YAML file
+  simulation_api: "../simulation_bridge/resources/inmemory/client.py"
 protocols:
   - id: "httpProtocol"
     type: "http"
@@ -110,6 +113,43 @@ devices:
         initial_value: "ON"
 independent_communication: True
 device_update_delay_ms: 10 # Update every 10 seconds if independent_communication is False
+```
+
+#### Simulation Bridge AMQP Configuration
+
+Use the `simulation_bridge` section to define the file paths required by the
+Simulation Bridge runtime. The emulator resolves the values relative to the
+current YAML file and passes them to the protocol instance so it can start the
+simulation. Within a protocol configuration you can reference these values by
+using the `${simulation_bridge.client_config}` and
+`${simulation_bridge.simulation_api}` placeholders.
+
+```yaml
+simulation_bridge:
+  client_config: "./simulation_bridge/config/client_config.yaml"
+  simulation_api: "./simulation_bridge/api/simulation_api.py"
+protocols:
+  - id: "simBridgeAmqp"
+    type: "simulation_bridge_amqp"
+    config:
+      client_config: "${simulation_bridge.client_config}"
+      simulation_api: "${simulation_bridge.simulation_api}"
+devices:
+  - id: "device1"
+    protocol_id: "simBridgeAmqp"
+    sensors:
+      - id: "numericSensor"
+        type: "numeric"
+        update_time_ms: 1000
+        min_val: 0
+        max_val: 10
+        initial_value: 0
+    actuators:
+      - id: "demoActuator"
+        type: "string"
+        initial_value: "ON"
+independent_communication: True
+device_update_delay_ms: 1000
 ```
 
 #### MQTT Example Configuration File

--- a/python-mock-physical-twin/app/physical_twin_emulator.py
+++ b/python-mock-physical-twin/app/physical_twin_emulator.py
@@ -44,6 +44,7 @@ from app.device.actuator import Actuator
 from app.device.iot_device import IoTDevice
 from app.protocol.http_protocol import HttpProtocol
 from app.protocol.mqtt_protocol import MqttProtocol
+from app.protocol.simulation_bridge_amqp_protocol import SimulationBridgeAMQPProtocol
 from app.utils.emulator_utils import ProtocolType
 
 
@@ -73,6 +74,28 @@ def main(config_file):
     # Load configuration from YAML file
     config = load_devices_from_yaml(config_file)
 
+    config_dir = os.path.dirname(os.path.abspath(config_file))
+    simulation_bridge_config_raw = config.get('simulation_bridge', {})
+    simulation_bridge_config = {}
+    for key, value in simulation_bridge_config_raw.items():
+        if key in {'client_config', 'simulation_api'} and isinstance(value, str):
+            if not os.path.isabs(value):
+                simulation_bridge_config[key] = os.path.abspath(os.path.join(config_dir, value))
+            else:
+                simulation_bridge_config[key] = value
+        else:
+            simulation_bridge_config[key] = value
+
+    def resolve_simulation_bridge_reference(value):
+        if not isinstance(value, str):
+            return value
+        references = {
+            '${simulation_bridge.client_config}': simulation_bridge_config.get('client_config'),
+            '${simulation_bridge.simulation_api}': simulation_bridge_config.get('simulation_api'),
+        }
+        resolved_value = references.get(value)
+        return resolved_value if resolved_value else value
+
     protocol_dict = {}
     device_dict = {}
 
@@ -80,13 +103,32 @@ def main(config_file):
     for protocol_config in config['protocols']:
         # HTTP Protocol Support
         if protocol_config["type"] == ProtocolType.HTTP_PROTOCOL_TYPE.value:
+            resolved_config = {
+                key: resolve_simulation_bridge_reference(val)
+                for key, val in protocol_config["config"].items()
+            }
             protocol = HttpProtocol(protocol_id=protocol_config["id"],
-                                    config=protocol_config["config"])
+                                    config=resolved_config)
             protocol_dict[protocol.id] = protocol
         # MQTT Protocol Support
         elif protocol_config["type"] == ProtocolType.MQTT_PROTOCOL_TYPE.value:
+            resolved_config = {
+                key: resolve_simulation_bridge_reference(val)
+                for key, val in protocol_config["config"].items()
+            }
             protocol = MqttProtocol(protocol_id=protocol_config["id"],
-                                        config=protocol_config["config"])
+                                        config=resolved_config)
+            protocol_dict[protocol.id] = protocol
+        elif protocol_config["type"] == ProtocolType.SIMULATION_BRIDGE_AMQP.value:
+            resolved_config = {
+                key: resolve_simulation_bridge_reference(val)
+                for key, val in protocol_config.get("config", {}).items()
+            }
+            protocol = SimulationBridgeAMQPProtocol(
+                protocol_id=protocol_config["id"],
+                config=resolved_config,
+                simulation_bridge_config=simulation_bridge_config,
+            )
             protocol_dict[protocol.id] = protocol
         else:
             print(f'Protocol Type not found ! Wrong Type: {protocol_config["type"]}')

--- a/python-mock-physical-twin/app/protocol/simulation_bridge_amqp_protocol.py
+++ b/python-mock-physical-twin/app/protocol/simulation_bridge_amqp_protocol.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Dict, Optional
+
+from app.protocol.protocol import (
+    InvalidConfigurationError,
+    Protocol,
+    validate_dict_keys,
+)
+from app.utils.emulator_utils import ProtocolType
+
+if TYPE_CHECKING:
+    from app.device.iot_device import IoTDevice
+
+
+class SimulationBridgeAMQPProtocol(Protocol):
+    """Protocol adapter that proxies device telemetry to the Simulation Bridge."""
+
+    _REQUIRED_SIM_BRIDGE_KEYS = ["client_config", "simulation_api"]
+
+    def __init__(
+        self,
+        protocol_id: str,
+        device_dict: Optional[Dict[str, IoTDevice]] = None,
+        config: Optional[Dict] = None,
+        simulation_bridge_config: Optional[Dict[str, str]] = None,
+    ) -> None:
+        self.simulation_bridge_config = simulation_bridge_config or {}
+        super().__init__(
+            protocol_id,
+            ProtocolType.SIMULATION_BRIDGE_AMQP,
+            device_dict,
+            config or {},
+        )
+        self._validate_simulation_bridge_config()
+        self.client_config_path = Path(self.simulation_bridge_config["client_config"]).resolve()
+        self.simulation_api_path = Path(self.simulation_bridge_config["simulation_api"]).resolve()
+
+    def start(self) -> None:  # pragma: no cover - integration handled by adapter runtime
+        print(
+            "Starting Simulation Bridge AMQP protocol with client config "
+            f"{self.client_config_path} and API {self.simulation_api_path}"
+        )
+
+    def stop(self) -> None:  # pragma: no cover - lifecycle managed externally
+        print("Stopping Simulation Bridge AMQP protocol")
+
+    def validate_config(self) -> None:
+        """Validate that the protocol specific configuration is present."""
+        # No mandatory keys defined yet for the AMQP adapter configuration.
+        # The Simulation Bridge configuration contains the mandatory information.
+        if self.config is None:
+            self.config = {}
+
+    def publish_sensor_telemetry_data(self, device_id, sensor_id, payload):
+        """Placeholder for future per-sensor telemetry publishing."""
+        pass
+
+    def publish_device_telemetry_data(self, device_id, payload):
+        """Placeholder for future aggregated telemetry publishing."""
+        pass
+
+    def _validate_simulation_bridge_config(self) -> None:
+        if not validate_dict_keys(self.simulation_bridge_config, self._REQUIRED_SIM_BRIDGE_KEYS):
+            raise InvalidConfigurationError(self._REQUIRED_SIM_BRIDGE_KEYS)

--- a/python-mock-physical-twin/app/utils/emulator_utils.py
+++ b/python-mock-physical-twin/app/utils/emulator_utils.py
@@ -43,6 +43,7 @@ class ProtocolType(Enum):
     """
     HTTP_PROTOCOL_TYPE = "http"
     MQTT_PROTOCOL_TYPE = "mqtt"
+    SIMULATION_BRIDGE_AMQP = "simulation_bridge_amqp"
 
 
 class TimeUnit(Enum):


### PR DESCRIPTION
## Summary
- add the Simulation Bridge AMQP protocol enum entry and adapter implementation stub
- wire the physical twin emulator to resolve simulation bridge paths and instantiate the new protocol
- extend the README YAML examples with simulation bridge configuration guidance

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dabedeb2148333b09718a97aa11d12