### PR TITLE
Add MQTT simulation bridge protocol adapter

### DIFF
--- a/python-mock-physical-twin/app/physical_twin_emulator.py
+++ b/python-mock-physical-twin/app/physical_twin_emulator.py
@@ -45,6 +45,7 @@ from app.device.iot_device import IoTDevice
 from app.protocol.http_protocol import HttpProtocol
 from app.protocol.mqtt_protocol import MqttProtocol
 from app.protocol.simulation_bridge_amqp_protocol import SimulationBridgeAmqpProtocol
+from app.protocol.simulation_bridge_mqtt_protocol import SimulationBridgeMqttProtocol
 from app.protocol.simulation_bridge_rest_protocol import SimulationBridgeRestProtocol
 from app.utils.emulator_utils import ProtocolType
 
@@ -128,6 +129,13 @@ def main(config_file):
             protocol_dict[protocol.id] = protocol
         elif protocol_config["type"] == ProtocolType.SIMULATION_BRIDGE_AMQP_PROTOCOL_TYPE.value:
             protocol = SimulationBridgeAmqpProtocol(
+                protocol_id=protocol_config["id"],
+                device_dict=device_dict,
+                config=protocol_config["config"],
+            )
+            protocol_dict[protocol.id] = protocol
+        elif protocol_config["type"] == ProtocolType.SIMULATION_BRIDGE_MQTT_PROTOCOL_TYPE.value:
+            protocol = SimulationBridgeMqttProtocol(
                 protocol_id=protocol_config["id"],
                 device_dict=device_dict,
                 config=protocol_config["config"],

--- a/python-mock-physical-twin/app/protocol/__init__.py
+++ b/python-mock-physical-twin/app/protocol/__init__.py
@@ -4,11 +4,13 @@
 from .http_protocol import HttpProtocol
 from .mqtt_protocol import MqttProtocol
 from .simulation_bridge_amqp_protocol import SimulationBridgeAmqpProtocol
+from .simulation_bridge_mqtt_protocol import SimulationBridgeMqttProtocol
 from .simulation_bridge_rest_protocol import SimulationBridgeRestProtocol
 
 __all__ = [
     "HttpProtocol",
     "MqttProtocol",
     "SimulationBridgeAmqpProtocol",
+    "SimulationBridgeMqttProtocol",
     "SimulationBridgeRestProtocol",
 ]

--- a/python-mock-physical-twin/app/protocol/simulation_bridge_mqtt_protocol.py
+++ b/python-mock-physical-twin/app/protocol/simulation_bridge_mqtt_protocol.py
@@ -1,0 +1,268 @@
+"""Simulation Bridge protocol that exchanges messages through MQTT."""
+
+from __future__ import annotations
+
+import json
+import ssl
+import threading
+from pathlib import Path
+from types import MethodType
+from typing import TYPE_CHECKING, Any, Dict, Optional
+from uuid import uuid4
+
+import paho.mqtt.client as mqtt
+import yaml
+
+from app.device.sensor import Sensor
+from app.protocol.protocol import (
+    InvalidConfigurationError,
+    Protocol,
+    validate_dict_keys,
+)
+from app.utils.emulator_utils import ProtocolType
+
+if TYPE_CHECKING:
+    from app.device.iot_device import IoTDevice
+
+
+class SimulationBridgeMqttProtocol(Protocol):
+    """Protocol that forwards device telemetry to the simulation bridge via MQTT."""
+
+    def __init__(
+        self,
+        protocol_id: str,
+        device_dict: Optional[Dict[str, "IoTDevice"]] = None,
+        config: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        super().__init__(
+            protocol_id,
+            ProtocolType.SIMULATION_BRIDGE_MQTT_PROTOCOL_TYPE,
+            device_dict,
+            config,
+        )
+
+        self.base_path = Path(self.config.get("base_path", ".")).resolve()
+        self.client_config_path = self._resolve_path(self.config["client_config"])
+        self.simulation_api_path = self._resolve_path(self.config["simulation_api"])
+
+        aggregate_cfg = self.config.get("aggregate", {})
+        self.aggregate_device_id: str = aggregate_cfg["device_id"]
+        self.aggregate_sensor_id: str = aggregate_cfg["sensor_id"]
+        self.aggregate_sensor_config: Optional[Dict[str, Any]] = aggregate_cfg.get(
+            "sensor_config"
+        )
+
+        self.client_config = self._load_yaml(self.client_config_path)
+        self.simulation_payload = self._load_yaml(self.simulation_api_path)
+
+        self._validate_client_config(self.client_config)
+        mqtt_cfg = self.client_config["mqtt"]
+
+        self._host: str = mqtt_cfg.get("host", "localhost")
+        self._port: int = int(mqtt_cfg.get("port", 1883))
+        self._keepalive: int = int(mqtt_cfg.get("keepalive", 60))
+        self._username: Optional[str] = mqtt_cfg.get("username")
+        self._password: Optional[str] = mqtt_cfg.get("password")
+        self._qos: int = int(mqtt_cfg.get("qos", 0))
+        self._input_topic: str = mqtt_cfg["input_topic"]
+        self._output_topic: str = mqtt_cfg["output_topic"]
+        self._client_id: str = mqtt_cfg.get("client_id", f"simulation-bridge-{uuid4()}")
+        self._tls_config = mqtt_cfg.get("tls")
+
+        self.client: Optional[mqtt.Client] = None
+        self._stop_event = threading.Event()
+        self._sensor_lock = threading.Lock()
+        self._aggregate_sensor: Optional[Sensor] = None
+
+    def validate_config(self) -> None:  # type: ignore[override]
+        required_keys = ["client_config", "simulation_api", "aggregate"]
+        if not validate_dict_keys(self.config, required_keys):
+            raise InvalidConfigurationError(required_keys)
+
+        aggregate_cfg = self.config.get("aggregate", {})
+        if not validate_dict_keys(aggregate_cfg, ["device_id", "sensor_id"]):
+            raise InvalidConfigurationError(["aggregate.device_id", "aggregate.sensor_id"])
+
+    def start(self) -> None:  # type: ignore[override]
+        print(f"Starting protocol: {self.id} Type: {self.type}")
+        self._stop_event.clear()
+        self._ensure_aggregate_sensor()
+        self._initialize_client()
+
+    def stop(self) -> None:  # type: ignore[override]
+        print(f"Stopping protocol: {self.id} Type: {self.type}")
+        self._stop_event.set()
+        client = self.client
+        if client is not None:
+            try:
+                client.unsubscribe(self._output_topic)
+            except Exception:  # pylint: disable=broad-except
+                pass
+            try:
+                client.disconnect()
+            except Exception:  # pylint: disable=broad-except
+                pass
+            finally:
+                try:
+                    client.loop_stop()
+                except RuntimeError:
+                    pass
+        self.client = None
+
+    def publish_sensor_telemetry_data(self, device_id, sensor_id, payload):  # type: ignore[override]
+        pass
+
+    def publish_device_telemetry_data(self, device_id, payload):  # type: ignore[override]
+        pass
+
+    def _initialize_client(self) -> None:
+        client = mqtt.Client(client_id=self._client_id)
+        client.on_connect = self._handle_connect
+        client.on_message = self._handle_message
+
+        if self._username:
+            client.username_pw_set(self._username, self._password)
+
+        self._configure_tls(client)
+
+        self.client = client
+        client.connect(self._host, self._port, self._keepalive)
+        client.loop_start()
+
+    def _configure_tls(self, client: mqtt.Client) -> None:
+        tls_cfg = self._tls_config
+        if not tls_cfg:
+            return
+
+        if isinstance(tls_cfg, dict):
+            ca_certs = tls_cfg.get("ca_certs")
+            certfile = tls_cfg.get("certfile")
+            keyfile = tls_cfg.get("keyfile")
+            tls_version = str(tls_cfg.get("tls_version", "TLSv1_2")).upper()
+            insecure = bool(tls_cfg.get("insecure", False))
+
+            version_map = {
+                "TLS": getattr(ssl, "PROTOCOL_TLS", ssl.PROTOCOL_TLS_CLIENT),
+                "TLS_CLIENT": ssl.PROTOCOL_TLS_CLIENT,
+                "TLSV1": getattr(ssl, "PROTOCOL_TLSv1", ssl.PROTOCOL_TLS_CLIENT),
+                "TLSV1_1": getattr(ssl, "PROTOCOL_TLSv1_1", ssl.PROTOCOL_TLS_CLIENT),
+                "TLSV1_2": getattr(ssl, "PROTOCOL_TLSv1_2", ssl.PROTOCOL_TLS_CLIENT),
+                "TLSV1_3": getattr(ssl, "PROTOCOL_TLS", ssl.PROTOCOL_TLS_CLIENT),
+            }
+            version = version_map.get(tls_version, ssl.PROTOCOL_TLS_CLIENT)
+            client.tls_set(
+                ca_certs=self._resolve_optional_path(ca_certs),
+                certfile=self._resolve_optional_path(certfile),
+                keyfile=self._resolve_optional_path(keyfile),
+                cert_reqs=ssl.CERT_REQUIRED,
+                tls_version=version,
+            )
+            client.tls_insecure_set(insecure)
+        elif isinstance(tls_cfg, bool) and tls_cfg:
+            client.tls_set(
+                cert_reqs=ssl.CERT_REQUIRED,
+                tls_version=ssl.PROTOCOL_TLS_CLIENT,
+            )
+            client.tls_insecure_set(False)
+
+    def _handle_connect(self, client, userdata, flags, rc):  # pylint: disable=unused-argument
+        if rc != 0:
+            print(f"MQTT connection failed with result code {rc}")
+            return
+
+        try:
+            client.subscribe(self._output_topic, qos=self._qos)
+        except Exception as exc:  # pylint: disable=broad-except
+            print(f"Failed to subscribe to simulation bridge topic {self._output_topic}: {exc}")
+            return
+
+        self._publish_simulation_request()
+
+    def _handle_message(self, client, userdata, message):  # pylint: disable=unused-argument
+        if self._stop_event.is_set():
+            return
+
+        payload_text = message.payload.decode("utf-8", errors="replace")
+        parsed: Any
+        try:
+            parsed = yaml.safe_load(payload_text)
+        except yaml.YAMLError:
+            try:
+                parsed = json.loads(payload_text)
+            except json.JSONDecodeError:
+                parsed = payload_text
+
+        sensor = self._ensure_aggregate_sensor()
+        if sensor is None:
+            return
+
+        with self._sensor_lock:
+            sensor.last_value = parsed
+            sensor.last_update_time = 0
+
+    def _publish_simulation_request(self) -> None:
+        client = self.client
+        if client is None:
+            return
+
+        try:
+            payload = json.dumps(self.simulation_payload)
+        except TypeError:
+            payload = yaml.dump(self.simulation_payload, default_flow_style=False)
+
+        client.publish(self._input_topic, payload, qos=self._qos)
+
+    def _ensure_aggregate_sensor(self) -> Optional[Sensor]:
+        with self._sensor_lock:
+            if self._aggregate_sensor is not None:
+                return self._aggregate_sensor
+
+            device = self.device_dict.get(self.aggregate_device_id)
+            if device is None:
+                return None
+
+            sensor = device.get_sensor_by_id(self.aggregate_sensor_id)
+            if sensor is None and self.aggregate_sensor_config is not None:
+                sensor = Sensor(id=self.aggregate_sensor_id, **self.aggregate_sensor_config)
+                device.sensors.append(sensor)
+
+            if sensor is None:
+                return None
+
+            sensor.last_value = sensor.last_value or {}
+            sensor.last_update_time = 0
+            sensor.update_value = MethodType(lambda self_sensor: self_sensor.last_value, sensor)
+
+            self._aggregate_sensor = sensor
+            return sensor
+
+    def _resolve_path(self, relative_path: str) -> Path:
+        path = Path(relative_path).expanduser()
+        if not path.is_absolute():
+            path = (self.base_path / path).resolve()
+        return path
+
+    def _resolve_optional_path(self, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        return str(self._resolve_path(value))
+
+    @staticmethod
+    def _load_yaml(path: Path) -> Dict[str, Any]:
+        with path.open("r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle) or {}
+        if not isinstance(data, dict):
+            raise ValueError(f"YAML file {path} did not contain a dictionary")
+        return data
+
+    @staticmethod
+    def _validate_client_config(config: Dict[str, Any]) -> None:
+        mqtt_cfg = config.get("mqtt")
+        if not isinstance(mqtt_cfg, dict):
+            raise InvalidConfigurationError(["client_config.mqtt"])
+
+        required_keys = ["host", "port", "input_topic", "output_topic"]
+        missing = [key for key in required_keys if key not in mqtt_cfg or mqtt_cfg[key] is None]
+        if missing:
+            raise InvalidConfigurationError([f"client_config.mqtt.{key}" for key in missing])
+

--- a/python-mock-physical-twin/app/utils/emulator_utils.py
+++ b/python-mock-physical-twin/app/utils/emulator_utils.py
@@ -39,6 +39,7 @@ class ProtocolType(Enum):
     HTTP_PROTOCOL_TYPE = "http"
     MQTT_PROTOCOL_TYPE = "mqtt"
     SIMULATION_BRIDGE_AMQP_PROTOCOL_TYPE = "simulation_bridge_amqp"
+    SIMULATION_BRIDGE_MQTT_PROTOCOL_TYPE = "simulation_bridge_mqtt"
     SIMULATION_BRIDGE_REST_PROTOCOL_TYPE = "simulation_bridge_rest"
 
 


### PR DESCRIPTION
## Summary
- add a SimulationBridgeMqttProtocol that loads MQTT client configuration and communicates with the simulation bridge
- register the new protocol with the emulator and extend the protocol type enumeration

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'blinker')*

------
https://chatgpt.com/codex/tasks/task_e_68dad2ea634483339fc723f79b2b27a2