### PR TITLE
Add React + TypeScript web console for Simulation Bridge

### DIFF
--- a/webapp/.eslintrc.cjs
+++ b/webapp/.eslintrc.cjs
@@ -1,0 +1,29 @@
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module'
+  },
+  env: {
+    browser: true,
+    es2021: true
+  },
+  plugins: ['@typescript-eslint', 'react', 'react-hooks', 'jsx-a11y'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:react/recommended',
+    'plugin:react-hooks/recommended',
+    'plugin:jsx-a11y/recommended'
+  ],
+  settings: {
+    react: {
+      version: 'detect'
+    }
+  },
+  rules: {
+    'react/react-in-jsx-scope': 'off',
+    '@typescript-eslint/explicit-function-return-type': 'off'
+  }
+};

--- a/webapp/README.md
+++ b/webapp/README.md
@@ -1,0 +1,31 @@
+# Simulation Bridge Webapp
+
+Interfaccia web moderna sviluppata con React + TypeScript per rendere Simulation Bridge accessibile e semplice da usare. La webapp fornisce dashboard, gestione configurazioni, progetti, automazioni, collaborazione e monitoraggio streaming.
+
+## Requisiti
+- Node.js >= 18
+- npm o yarn
+
+## Installazione e avvio
+```bash
+npm install
+npm run dev
+```
+La console di sviluppo sarà disponibile su [http://localhost:5173](http://localhost:5173).
+
+## Build di produzione
+```bash
+npm run build
+```
+I file ottimizzati saranno generati nella cartella `dist/`.
+
+## Struttura principale
+- `src/App.tsx`: definisce il routing principale della console.
+- `src/components/Layout.tsx`: layout con navigazione laterale e top bar.
+- `src/pages/`: raccolta delle pagine (Dashboard, Configurazioni, Progetti, Automazioni, Collaborazione, Streaming).
+
+## Linting
+```bash
+npm run lint
+```
+Esegue ESLint sulle sorgenti TypeScript/React.

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="it">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Simulation Bridge Web Console</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "simulation-bridge-webapp",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "lint": "eslint 'src/**/*.{ts,tsx}'"
+  },
+  "dependencies": {
+    "@emotion/react": "^11.11.1",
+    "@emotion/styled": "^11.11.0",
+    "@mui/icons-material": "^5.15.12",
+    "@mui/material": "^5.15.12",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@typescript-eslint/eslint-plugin": "^7.4.0",
+    "@typescript-eslint/parser": "^7.4.0",
+    "eslint": "^8.57.0",
+    "eslint-plugin-react": "^7.33.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-jsx-a11y": "^6.8.0",
+    "typescript": "^5.3.3",
+    "vite": "^5.1.0"
+  }
+}

--- a/webapp/public/favicon.svg
+++ b/webapp/public/favicon.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#00bcd4" />
+      <stop offset="100%" stop-color="#00658a" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#grad)" />
+  <path
+    d="M20 20h8l4 6 4-6h8l-12 18z"
+    fill="#fff"
+    stroke="#fff"
+    stroke-width="2"
+    stroke-linejoin="round"
+  />
+</svg>

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -1,0 +1,51 @@
+import { CssBaseline, ThemeProvider, createTheme } from '@mui/material';
+import { Route, Routes } from 'react-router-dom';
+import Layout from './components/Layout';
+import Dashboard from './pages/Dashboard';
+import Configurations from './pages/Configurations';
+import Projects from './pages/Projects';
+import Automations from './pages/Automations';
+import Collaboration from './pages/Collaboration';
+import Streaming from './pages/Streaming';
+
+const theme = createTheme({
+  palette: {
+    mode: 'light',
+    primary: {
+      main: '#00658a'
+    },
+    secondary: {
+      main: '#00bcd4'
+    },
+    background: {
+      default: '#f5f7fb',
+      paper: '#ffffff'
+    }
+  },
+  typography: {
+    fontFamily: 'Inter, Roboto, Helvetica, Arial, sans-serif'
+  },
+  shape: {
+    borderRadius: 12
+  }
+});
+
+function App() {
+  return (
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <Layout>
+        <Routes>
+          <Route path="/" element={<Dashboard />} />
+          <Route path="/configurations" element={<Configurations />} />
+          <Route path="/projects" element={<Projects />} />
+          <Route path="/automations" element={<Automations />} />
+          <Route path="/collaboration" element={<Collaboration />} />
+          <Route path="/streaming" element={<Streaming />} />
+        </Routes>
+      </Layout>
+    </ThemeProvider>
+  );
+}
+
+export default App;

--- a/webapp/src/components/Layout.tsx
+++ b/webapp/src/components/Layout.tsx
@@ -1,0 +1,173 @@
+import MenuIcon from '@mui/icons-material/Menu';
+import PlayArrowRoundedIcon from '@mui/icons-material/PlayArrowRounded';
+import {
+  AppBar,
+  Avatar,
+  Box,
+  Divider,
+  Drawer,
+  IconButton,
+  List,
+  ListItem,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Toolbar,
+  Typography
+} from '@mui/material';
+import { useMemo, useState } from 'react';
+import { NavLink, useLocation, useNavigate } from 'react-router-dom';
+import DashboardRoundedIcon from '@mui/icons-material/DashboardRounded';
+import SettingsSuggestRoundedIcon from '@mui/icons-material/SettingsSuggestRounded';
+import Inventory2RoundedIcon from '@mui/icons-material/Inventory2Rounded';
+import AutomationRoundedIcon from '@mui/icons-material/PrecisionManufacturingRounded';
+import GroupRoundedIcon from '@mui/icons-material/GroupsRounded';
+import StreamingRoundedIcon from '@mui/icons-material/Stream';
+
+const drawerWidth = 260;
+
+const navItems = [
+  { label: 'Dashboard', path: '/', icon: <DashboardRoundedIcon /> },
+  { label: 'Configurazioni', path: '/configurations', icon: <SettingsSuggestRoundedIcon /> },
+  { label: 'Progetti', path: '/projects', icon: <Inventory2RoundedIcon /> },
+  { label: 'Automazioni', path: '/automations', icon: <AutomationRoundedIcon /> },
+  { label: 'Collaborazione', path: '/collaboration', icon: <GroupRoundedIcon /> },
+  { label: 'Streaming', path: '/streaming', icon: <StreamingRoundedIcon /> }
+];
+
+interface LayoutProps {
+  children: React.ReactNode;
+}
+
+function Layout({ children }: LayoutProps) {
+  const [mobileOpen, setMobileOpen] = useState(false);
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const activeLabel = useMemo(() => {
+    const item = navItems.find((nav) => nav.path === location.pathname);
+    return item?.label ?? 'Simulation Bridge';
+  }, [location.pathname]);
+
+  const drawer = (
+    <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      <Box sx={{ p: 3 }}>
+        <Typography variant="h6" fontWeight={700} color="primary">
+          Simulation Bridge
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          Console web per orchestrare test e integrazioni
+        </Typography>
+      </Box>
+      <Divider />
+      <List sx={{ flexGrow: 1 }}>
+        {navItems.map((item) => (
+          <ListItem key={item.path} disablePadding>
+            <ListItemButton
+              component={NavLink}
+              to={item.path}
+              onClick={() => setMobileOpen(false)}
+              sx={{
+                borderRadius: 2,
+                mx: 1,
+                my: 0.5,
+                '&.active': {
+                  backgroundColor: 'rgba(0, 101, 138, 0.12)',
+                  color: 'primary.main'
+                }
+              }}
+            >
+              <ListItemIcon sx={{ color: 'inherit', minWidth: 36 }}>{item.icon}</ListItemIcon>
+              <ListItemText primary={item.label} />
+            </ListItemButton>
+          </ListItem>
+        ))}
+      </List>
+      <Divider />
+      <Box sx={{ p: 3, display: 'flex', gap: 2, alignItems: 'center' }}>
+        <Avatar sx={{ bgcolor: 'primary.main' }}>SB</Avatar>
+        <Box>
+          <Typography variant="subtitle2">Operatore Bridge</Typography>
+          <Typography variant="caption" color="text.secondary">
+            admin@simulation.bridge
+          </Typography>
+        </Box>
+      </Box>
+    </Box>
+  );
+
+  return (
+    <Box sx={{ display: 'flex', height: '100vh', bgcolor: 'background.default' }}>
+      <AppBar
+        position="fixed"
+        elevation={0}
+        sx={{
+          zIndex: (theme) => theme.zIndex.drawer + 1,
+          bgcolor: 'background.paper',
+          borderBottom: (theme) => `1px solid ${theme.palette.divider}`,
+          color: 'text.primary'
+        }}
+      >
+        <Toolbar sx={{ display: 'flex', justifyContent: 'space-between' }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <IconButton
+              color="inherit"
+              edge="start"
+              onClick={() => setMobileOpen(true)}
+              sx={{ display: { md: 'none', xs: 'inline-flex' } }}
+            >
+              <MenuIcon />
+            </IconButton>
+            <Typography variant="h6" fontWeight={600} sx={{ display: { xs: 'none', md: 'block' } }}>
+              {activeLabel}
+            </Typography>
+            <Typography variant="subtitle1" sx={{ display: { xs: 'block', md: 'none' } }}>
+              Simulation Bridge
+            </Typography>
+          </Box>
+          <IconButton color="primary" onClick={() => navigate('/streaming')} size="large">
+            <PlayArrowRoundedIcon />
+          </IconButton>
+        </Toolbar>
+      </AppBar>
+      <Box component="nav" sx={{ width: { md: drawerWidth }, flexShrink: { md: 0 } }}>
+        <Drawer
+          variant="temporary"
+          open={mobileOpen}
+          onClose={() => setMobileOpen(false)}
+          ModalProps={{ keepMounted: true }}
+          sx={{
+            display: { xs: 'block', md: 'none' },
+            '& .MuiDrawer-paper': { boxSizing: 'border-box', width: drawerWidth }
+          }}
+        >
+          {drawer}
+        </Drawer>
+        <Drawer
+          variant="permanent"
+          sx={{
+            display: { xs: 'none', md: 'block' },
+            '& .MuiDrawer-paper': { boxSizing: 'border-box', width: drawerWidth }
+          }}
+          open
+        >
+          {drawer}
+        </Drawer>
+      </Box>
+      <Box
+        component="main"
+        sx={{
+          flexGrow: 1,
+          p: { xs: 2, md: 4 },
+          width: { md: `calc(100% - ${drawerWidth}px)` },
+          mt: 8,
+          overflow: 'auto'
+        }}
+      >
+        {children}
+      </Box>
+    </Box>
+  );
+}
+
+export default Layout;

--- a/webapp/src/main.tsx
+++ b/webapp/src/main.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './styles/global.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/webapp/src/pages/Automations.tsx
+++ b/webapp/src/pages/Automations.tsx
@@ -1,0 +1,169 @@
+import AccessTimeRoundedIcon from '@mui/icons-material/AccessTimeRounded';
+import PlayArrowRoundedIcon from '@mui/icons-material/PlayArrowRounded';
+import SettingsSuggestRoundedIcon from '@mui/icons-material/SettingsSuggestRounded';
+import StopRoundedIcon from '@mui/icons-material/StopRounded';
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  Grid,
+  Stack,
+  TextField,
+  ToggleButton,
+  ToggleButtonGroup,
+  Typography
+} from '@mui/material';
+import { useState } from 'react';
+
+const schedules = [
+  {
+    id: 'sch-1',
+    name: 'Regression notturna',
+    frequency: 'Ogni notte alle 02:00',
+    nextRun: 'Prossima esecuzione: domani alle 02:00',
+    active: true
+  },
+  {
+    id: 'sch-2',
+    name: 'Stress test MQTT',
+    frequency: 'Ogni lunedì alle 06:30',
+    nextRun: 'Prossima esecuzione: lunedì 06:30',
+    active: false
+  }
+];
+
+function Automations() {
+  const [mode, setMode] = useState<'manual' | 'scheduled'>('manual');
+
+  return (
+    <Stack spacing={4}>
+      <Box>
+        <Typography variant="h4" fontWeight={700} gutterBottom>
+          Automazioni e Runbook
+        </Typography>
+        <Typography variant="body1" color="text.secondary">
+          Avvia, pianifica e monitora scenari ricorrenti riutilizzando le configurazioni del bridge.
+        </Typography>
+      </Box>
+
+      <Card>
+        <CardContent>
+          <Stack direction={{ xs: 'column', md: 'row' }} spacing={3} alignItems={{ md: 'center' }}>
+            <Stack spacing={1}>
+              <Typography variant="h6" fontWeight={600}>
+                Avvia nuova automazione
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Seleziona la configurazione da utilizzare e scegli se eseguire subito o schedulare.
+              </Typography>
+            </Stack>
+            <ToggleButtonGroup
+              color="primary"
+              exclusive
+              value={mode}
+              onChange={(_, value) => value && setMode(value)}
+            >
+              <ToggleButton value="manual">Esecuzione immediata</ToggleButton>
+              <ToggleButton value="scheduled">Pianifica esecuzione</ToggleButton>
+            </ToggleButtonGroup>
+          </Stack>
+
+          <Grid container spacing={2} sx={{ mt: 1 }}>
+            <Grid item xs={12} md={6}>
+              <TextField label="Configurazione" fullWidth placeholder="Seleziona configurazione" />
+            </Grid>
+            <Grid item xs={12} md={3}>
+              <TextField label="Branch" fullWidth placeholder="main" />
+            </Grid>
+            <Grid item xs={12} md={3}>
+              <TextField label="Variabile scenario" fullWidth placeholder="scenario_a" />
+            </Grid>
+          </Grid>
+
+          {mode === 'scheduled' ? (
+            <Grid container spacing={2} sx={{ mt: 1 }}>
+              <Grid item xs={12} md={4}>
+                <TextField label="Cadenza" fullWidth placeholder="0 2 * * *" />
+              </Grid>
+              <Grid item xs={12} md={4}>
+                <TextField label="Timezone" fullWidth placeholder="Europe/Rome" />
+              </Grid>
+              <Grid item xs={12} md={4}>
+                <TextField label="Durata massima" fullWidth placeholder="120 min" />
+              </Grid>
+            </Grid>
+          ) : (
+            <Grid container spacing={2} sx={{ mt: 1 }}>
+              <Grid item xs={12} md={6}>
+                <TextField label="Timeout" fullWidth placeholder="60 min" />
+              </Grid>
+              <Grid item xs={12} md={6}>
+                <TextField label="Ripetizioni" fullWidth placeholder="3" />
+              </Grid>
+            </Grid>
+          )}
+
+          <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} sx={{ mt: 3 }}>
+            <Button startIcon={<PlayArrowRoundedIcon />} variant="contained" color="primary">
+              Avvia automazione
+            </Button>
+            <Button startIcon={<SettingsSuggestRoundedIcon />} variant="outlined">
+              Salva come workflow
+            </Button>
+          </Stack>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent>
+          <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 2 }}>
+            <AccessTimeRoundedIcon color="primary" />
+            <Typography variant="h6" fontWeight={600}>
+              Pianificazioni attive
+            </Typography>
+          </Stack>
+
+          <Stack spacing={2}>
+            {schedules.map((schedule) => (
+              <Card key={schedule.id} variant="outlined">
+                <CardContent>
+                  <Stack direction={{ xs: 'column', md: 'row' }} justifyContent="space-between" gap={2}>
+                    <Box>
+                      <Typography variant="subtitle1" fontWeight={600}>
+                        {schedule.name}
+                      </Typography>
+                      <Typography variant="body2" color="text.secondary">
+                        {schedule.frequency}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        {schedule.nextRun}
+                      </Typography>
+                    </Box>
+                    <Stack direction="row" spacing={1} alignItems="center">
+                      <Chip
+                        label={schedule.active ? 'Attiva' : 'In pausa'}
+                        color={schedule.active ? 'success' : 'default'}
+                        variant={schedule.active ? 'filled' : 'outlined'}
+                      />
+                      <Button
+                        variant={schedule.active ? 'outlined' : 'contained'}
+                        color={schedule.active ? 'inherit' : 'primary'}
+                        startIcon={schedule.active ? <StopRoundedIcon /> : <PlayArrowRoundedIcon />}
+                      >
+                        {schedule.active ? 'Metti in pausa' : 'Riattiva'}
+                      </Button>
+                    </Stack>
+                  </Stack>
+                </CardContent>
+              </Card>
+            ))}
+          </Stack>
+        </CardContent>
+      </Card>
+    </Stack>
+  );
+}
+
+export default Automations;

--- a/webapp/src/pages/Collaboration.tsx
+++ b/webapp/src/pages/Collaboration.tsx
@@ -1,0 +1,152 @@
+import AddCommentRoundedIcon from '@mui/icons-material/AddCommentRounded';
+import CloudUploadRoundedIcon from '@mui/icons-material/CloudUploadRounded';
+import ShareRoundedIcon from '@mui/icons-material/ShareRounded';
+import {
+  Avatar,
+  AvatarGroup,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  Divider,
+  Grid,
+  Stack,
+  TextField,
+  Typography
+} from '@mui/material';
+
+const collaborators = [
+  { name: 'Sara', role: 'Digital Twin Engineer', color: '#00bcd4' },
+  { name: 'Marco', role: 'Process Owner', color: '#ff9800' },
+  { name: 'Anna', role: 'QA Specialist', color: '#8e24aa' }
+];
+
+function Collaboration() {
+  return (
+    <Stack spacing={4}>
+      <Box>
+        <Typography variant="h4" fontWeight={700} gutterBottom>
+          Collaborazione e Condivisione
+        </Typography>
+        <Typography variant="body1" color="text.secondary">
+          Coordina i team multidisciplinari condividendo payload, risultati e note operative.
+        </Typography>
+      </Box>
+
+      <Grid container spacing={3}>
+        <Grid item xs={12} md={7}>
+          <Card>
+            <CardContent>
+              <Stack direction={{ xs: 'column', md: 'row' }} justifyContent="space-between" spacing={3}>
+                <Box>
+                  <Typography variant="h6" fontWeight={600}>
+                    Note condivise per l&apos;esecuzione corrente
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary">
+                    Aggiungi aggiornamenti o richieste per il team prima di avviare una nuova campagna.
+                  </Typography>
+                </Box>
+                <Button variant="contained" startIcon={<AddCommentRoundedIcon />}>
+                  Aggiungi nota
+                </Button>
+              </Stack>
+
+              <Stack spacing={2} sx={{ mt: 3 }}>
+                <Box
+                  sx={{
+                    p: 2,
+                    borderRadius: 2,
+                    bgcolor: 'grey.50',
+                    border: (theme) => `1px solid ${theme.palette.divider}`
+                  }}
+                >
+                  <Typography variant="subtitle2" fontWeight={600}>
+                    Aggiornare payload MQTT con i nuovi topic di sicurezza
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    Inserita da Sara • 15 minuti fa
+                  </Typography>
+                </Box>
+                <Box
+                  sx={{
+                    p: 2,
+                    borderRadius: 2,
+                    bgcolor: 'grey.50',
+                    border: (theme) => `1px solid ${theme.palette.divider}`
+                  }}
+                >
+                  <Typography variant="subtitle2" fontWeight={600}>
+                    Richiesta report PDF per il comitato di revisione
+                  </Typography>
+                  <Typography variant="caption" color="text.secondary">
+                    Inserita da Anna • 2 ore fa
+                  </Typography>
+                </Box>
+              </Stack>
+
+              <Divider sx={{ my: 3 }} />
+
+              <Stack spacing={2}>
+                <Typography variant="subtitle1" fontWeight={600}>
+                  Condividi un nuovo allegato
+                </Typography>
+                <TextField label="Descrizione" fullWidth placeholder="Es. payload di test robotica" />
+                <Button variant="outlined" startIcon={<CloudUploadRoundedIcon />}>Carica file</Button>
+              </Stack>
+            </CardContent>
+          </Card>
+        </Grid>
+
+        <Grid item xs={12} md={5}>
+          <Card sx={{ height: '100%' }}>
+            <CardContent>
+              <Typography variant="h6" fontWeight={600} gutterBottom>
+                Team coinvolti
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Gestisci i permessi di lettura e scrittura sui progetti condivisi.
+              </Typography>
+
+              <AvatarGroup max={4} sx={{ mt: 3 }}>
+                {collaborators.map((member) => (
+                  <Avatar key={member.name} sx={{ bgcolor: member.color }}>
+                    {member.name.charAt(0)}
+                  </Avatar>
+                ))}
+              </AvatarGroup>
+
+              <Stack spacing={2} sx={{ mt: 3 }}>
+                {collaborators.map((member) => (
+                  <Box
+                    key={member.name}
+                    sx={{
+                      p: 2,
+                      borderRadius: 2,
+                      bgcolor: 'background.default',
+                      border: (theme) => `1px solid ${theme.palette.divider}`
+                    }}
+                  >
+                    <Stack direction="row" justifyContent="space-between" alignItems="center">
+                      <Box>
+                        <Typography variant="subtitle1" fontWeight={600}>
+                          {member.name}
+                        </Typography>
+                        <Typography variant="caption" color="text.secondary">
+                          {member.role}
+                        </Typography>
+                      </Box>
+                      <Chip icon={<ShareRoundedIcon />} label="Condiviso" color="primary" variant="outlined" />
+                    </Stack>
+                  </Box>
+                ))}
+              </Stack>
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+    </Stack>
+  );
+}
+
+export default Collaboration;

--- a/webapp/src/pages/Configurations.tsx
+++ b/webapp/src/pages/Configurations.tsx
@@ -1,0 +1,234 @@
+import AddRoundedIcon from '@mui/icons-material/AddRounded';
+import SaveRoundedIcon from '@mui/icons-material/SaveRounded';
+import SettingsEthernetRoundedIcon from '@mui/icons-material/SettingsEthernetRounded';
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  Divider,
+  FormControl,
+  Grid,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  Switch,
+  TextField,
+  Typography
+} from '@mui/material';
+import { useState } from 'react';
+
+const defaultConfig = {
+  name: 'Bridge principale',
+  protocol: 'mqtt',
+  tls: true,
+  host: 'broker.internal',
+  port: 8883,
+  username: 'bridge-user',
+  password: '••••••••',
+  restEndpoint: 'https://bridge.internal/api/v1/execute',
+  logLevel: 'INFO'
+};
+
+function Configurations() {
+  const [config, setConfig] = useState(defaultConfig);
+
+  const handleChange = (field: keyof typeof config, value: string | number | boolean) => {
+    setConfig((prev) => ({ ...prev, [field]: value }));
+  };
+
+  return (
+    <Stack spacing={4}>
+      <Box>
+        <Typography variant="h4" fontWeight={700} gutterBottom>
+          Configurazioni del Bridge
+        </Typography>
+        <Typography variant="body1" color="text.secondary">
+          Modifica i parametri dei protocolli, esporta i profili e applica le configurazioni ai nodi.
+        </Typography>
+      </Box>
+
+      <Grid container spacing={3}>
+        <Grid item xs={12} md={7}>
+          <Card>
+            <CardContent>
+              <Stack direction="row" justifyContent="space-between" alignItems="center">
+                <Stack direction="row" spacing={1} alignItems="center">
+                  <SettingsEthernetRoundedIcon color="primary" />
+                  <Typography variant="h6" fontWeight={600}>
+                    Parametri principali
+                  </Typography>
+                </Stack>
+                <Chip label="MQTT attivo" color="primary" />
+              </Stack>
+
+              <Grid container spacing={2} sx={{ mt: 1 }}>
+                <Grid item xs={12} md={6}>
+                  <TextField
+                    label="Nome"
+                    fullWidth
+                    value={config.name}
+                    onChange={(event) => handleChange('name', event.target.value)}
+                  />
+                </Grid>
+                <Grid item xs={12} md={6}>
+                  <FormControl fullWidth>
+                    <InputLabel id="protocol-label">Protocollo</InputLabel>
+                    <Select
+                      labelId="protocol-label"
+                      label="Protocollo"
+                      value={config.protocol}
+                      onChange={(event) => handleChange('protocol', event.target.value)}
+                    >
+                      <MenuItem value="mqtt">MQTT</MenuItem>
+                      <MenuItem value="rabbitmq">RabbitMQ</MenuItem>
+                      <MenuItem value="rest">REST</MenuItem>
+                    </Select>
+                  </FormControl>
+                </Grid>
+                <Grid item xs={12} md={6}>
+                  <TextField
+                    label="Host"
+                    fullWidth
+                    value={config.host}
+                    onChange={(event) => handleChange('host', event.target.value)}
+                  />
+                </Grid>
+                <Grid item xs={12} md={3}>
+                  <TextField
+                    label="Porta"
+                    fullWidth
+                    type="number"
+                    value={config.port}
+                    onChange={(event) => handleChange('port', Number(event.target.value))}
+                  />
+                </Grid>
+                <Grid item xs={12} md={3}>
+                  <Stack direction="row" spacing={1} alignItems="center" sx={{ height: '100%' }}>
+                    <Typography variant="subtitle2">TLS</Typography>
+                    <Switch
+                      checked={config.tls}
+                      onChange={(event) => handleChange('tls', event.target.checked)}
+                    />
+                  </Stack>
+                </Grid>
+                <Grid item xs={12} md={6}>
+                  <TextField
+                    label="Username"
+                    fullWidth
+                    value={config.username}
+                    onChange={(event) => handleChange('username', event.target.value)}
+                  />
+                </Grid>
+                <Grid item xs={12} md={6}>
+                  <TextField
+                    label="Password"
+                    type="password"
+                    fullWidth
+                    value={config.password}
+                    onChange={(event) => handleChange('password', event.target.value)}
+                  />
+                </Grid>
+                <Grid item xs={12}>
+                  <TextField
+                    label="Endpoint REST di fallback"
+                    fullWidth
+                    value={config.restEndpoint}
+                    onChange={(event) => handleChange('restEndpoint', event.target.value)}
+                  />
+                </Grid>
+                <Grid item xs={12} md={6}>
+                  <FormControl fullWidth>
+                    <InputLabel id="log-label">Log level</InputLabel>
+                    <Select
+                      labelId="log-label"
+                      label="Log level"
+                      value={config.logLevel}
+                      onChange={(event) => handleChange('logLevel', event.target.value)}
+                    >
+                      <MenuItem value="DEBUG">DEBUG</MenuItem>
+                      <MenuItem value="INFO">INFO</MenuItem>
+                      <MenuItem value="WARNING">WARNING</MenuItem>
+                      <MenuItem value="ERROR">ERROR</MenuItem>
+                    </Select>
+                  </FormControl>
+                </Grid>
+              </Grid>
+
+              <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} sx={{ mt: 3 }}>
+                <Button variant="contained" color="primary" startIcon={<SaveRoundedIcon />}>
+                  Salva configurazione
+                </Button>
+                <Button variant="outlined" startIcon={<AddRoundedIcon />}>
+                  Duplica profilo
+                </Button>
+              </Stack>
+            </CardContent>
+          </Card>
+        </Grid>
+
+        <Grid item xs={12} md={5}>
+          <Card sx={{ height: '100%' }}>
+            <CardContent>
+              <Typography variant="h6" fontWeight={600} gutterBottom>
+                Snippet YAML generato
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Copia il contenuto per aggiornarlo nei deployment esistenti o salvarlo come template.
+              </Typography>
+              <Box
+                component="pre"
+                sx={{
+                  mt: 2,
+                  bgcolor: 'grey.100',
+                  p: 2,
+                  borderRadius: 2,
+                  fontSize: 13,
+                  overflowX: 'auto'
+                }}
+              >
+{`bridge:\n  name: ${config.name}\n  protocol: ${config.protocol}\n  tls: ${config.tls}\n  host: ${config.host}\n  port: ${config.port}\n  credentials:\n    username: ${config.username}\n    password: ${config.password}\n  restFallback: ${config.restEndpoint}\nlogging:\n  level: ${config.logLevel}`}
+              </Box>
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+
+      <Card>
+        <CardContent>
+          <Typography variant="h6" fontWeight={600} gutterBottom>
+            Adapter abilitati
+          </Typography>
+          <Divider sx={{ my: 2 }} />
+          <Grid container spacing={2}>
+            {[{ label: 'MQTT broker', enabled: true }, { label: 'RabbitMQ', enabled: false }, { label: 'REST orchestrator', enabled: true }].map(
+              (adapter) => (
+                <Grid item xs={12} md={4} key={adapter.label}>
+                  <Card variant="outlined">
+                    <CardContent>
+                      <Stack direction="row" justifyContent="space-between" alignItems="center">
+                        <Typography variant="subtitle1" fontWeight={600}>
+                          {adapter.label}
+                        </Typography>
+                        <Switch defaultChecked={adapter.enabled} />
+                      </Stack>
+                      <Typography variant="body2" color="text.secondary">
+                        {adapter.enabled
+                          ? 'Attivo e pronto a ricevere richieste.'
+                          : 'Disabilitato, abilitalo per utilizzarlo nelle simulazioni.'}
+                      </Typography>
+                    </CardContent>
+                  </Card>
+                </Grid>
+              )
+            )}
+          </Grid>
+        </CardContent>
+      </Card>
+    </Stack>
+  );
+}
+
+export default Configurations;

--- a/webapp/src/pages/Dashboard.tsx
+++ b/webapp/src/pages/Dashboard.tsx
@@ -1,0 +1,261 @@
+import AssessmentRoundedIcon from '@mui/icons-material/AssessmentRounded';
+import CloudSyncRoundedIcon from '@mui/icons-material/CloudSyncRounded';
+import RocketLaunchRoundedIcon from '@mui/icons-material/RocketLaunchRounded';
+import WarningAmberRoundedIcon from '@mui/icons-material/WarningAmberRounded';
+import {
+  Box,
+  Card,
+  CardContent,
+  Chip,
+  Grid,
+  LinearProgress,
+  Stack,
+  Typography
+} from '@mui/material';
+import { useMemo } from 'react';
+
+const runs = [
+  {
+    id: 'run-1',
+    project: 'Linea di produzione 4.0',
+    configuration: 'MQTT + REST orchestration',
+    status: 'running',
+    progress: 68,
+    owner: 'Team Digital Twin'
+  },
+  {
+    id: 'run-2',
+    project: 'Robotica collaborativa',
+    configuration: 'RabbitMQ real-time streaming',
+    status: 'completed',
+    progress: 100,
+    owner: 'Lab Automazione'
+  },
+  {
+    id: 'run-3',
+    project: 'Fonderia predittiva',
+    configuration: 'REST analytics',
+    status: 'error',
+    progress: 5,
+    owner: 'Ops Quality'
+  }
+];
+
+function StatusChip({ status }: { status: string }) {
+  const color = useMemo(() => {
+    switch (status) {
+      case 'running':
+        return 'primary';
+      case 'completed':
+        return 'success';
+      case 'error':
+        return 'error';
+      default:
+        return 'default';
+    }
+  }, [status]);
+
+  const label = useMemo(() => {
+    switch (status) {
+      case 'running':
+        return 'In esecuzione';
+      case 'completed':
+        return 'Completata';
+      case 'error':
+        return 'Errore';
+      default:
+        return status;
+    }
+  }, [status]);
+
+  return <Chip label={label} color={color as any} size="small" variant="filled" />;
+}
+
+function Dashboard() {
+  return (
+    <Stack spacing={4}>
+      <Box>
+        <Typography variant="h4" fontWeight={700} gutterBottom>
+          Benvenuto nella console Simulation Bridge
+        </Typography>
+        <Typography variant="body1" color="text.secondary">
+          Monitora lo stato dei bridge, visualizza le prestazioni e controlla ogni esecuzione.
+        </Typography>
+      </Box>
+
+      <Grid container spacing={3}>
+        <Grid item xs={12} md={4}>
+          <Card>
+            <CardContent>
+              <Stack direction="row" justifyContent="space-between" alignItems="center">
+                <Box>
+                  <Typography variant="subtitle2" color="text.secondary">
+                    Bridge attivi
+                  </Typography>
+                  <Typography variant="h3" fontWeight={700}>
+                    4
+                  </Typography>
+                </Box>
+                <CloudSyncRoundedIcon color="primary" fontSize="large" />
+              </Stack>
+              <Typography variant="body2" color="text.secondary" sx={{ mt: 2 }}>
+                2 orchestrazioni ibride e 2 canali streaming disponibili.
+              </Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+        <Grid item xs={12} md={4}>
+          <Card>
+            <CardContent>
+              <Stack direction="row" justifyContent="space-between" alignItems="center">
+                <Box>
+                  <Typography variant="subtitle2" color="text.secondary">
+                    Simulazioni oggi
+                  </Typography>
+                  <Typography variant="h3" fontWeight={700}>
+                    18
+                  </Typography>
+                </Box>
+                <RocketLaunchRoundedIcon color="secondary" fontSize="large" />
+              </Stack>
+              <Typography variant="body2" color="text.secondary" sx={{ mt: 2 }}>
+                Incluse 5 nuove richieste da team esterni.
+              </Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+        <Grid item xs={12} md={4}>
+          <Card>
+            <CardContent>
+              <Stack direction="row" justifyContent="space-between" alignItems="center">
+                <Box>
+                  <Typography variant="subtitle2" color="text.secondary">
+                    Incidenti ultimi 7 giorni
+                  </Typography>
+                  <Typography variant="h3" fontWeight={700}>
+                    1
+                  </Typography>
+                </Box>
+                <WarningAmberRoundedIcon color="error" fontSize="large" />
+              </Stack>
+              <Typography variant="body2" color="text.secondary" sx={{ mt: 2 }}>
+                Tutte le altre esecuzioni sono state completate con successo.
+              </Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+
+      <Card>
+        <CardContent>
+          <Stack direction={{ xs: 'column', md: 'row' }} justifyContent="space-between" spacing={3}>
+            <Box>
+              <Typography variant="h6" fontWeight={600} gutterBottom>
+                Esecuzioni correnti
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Controlla l&apos;avanzamento delle simulazioni orchestrate dal bridge.
+              </Typography>
+            </Box>
+            <Chip label="Ultimo aggiornamento: pochi secondi fa" color="default" />
+          </Stack>
+
+          <Stack spacing={3} sx={{ mt: 3 }}>
+            {runs.map((run) => (
+              <Box
+                key={run.id}
+                sx={{
+                  p: 3,
+                  borderRadius: 3,
+                  bgcolor: 'background.default',
+                  border: (theme) => `1px solid ${theme.palette.divider}`
+                }}
+              >
+                <Stack direction={{ xs: 'column', md: 'row' }} justifyContent="space-between" gap={2}>
+                  <Box>
+                    <Typography variant="subtitle1" fontWeight={600}>
+                      {run.project}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      {run.configuration}
+                    </Typography>
+                  </Box>
+                  <Stack direction="row" gap={2} alignItems="center">
+                    <StatusChip status={run.status} />
+                    <Typography variant="body2" color="text.secondary">
+                      Referente: {run.owner}
+                    </Typography>
+                  </Stack>
+                </Stack>
+                <Box sx={{ mt: 2 }}>
+                  <LinearProgress
+                    variant="determinate"
+                    value={run.progress}
+                    sx={{ height: 10, borderRadius: 5 }}
+                    color={run.status === 'error' ? 'error' : 'primary'}
+                  />
+                  <Typography variant="caption" color="text.secondary">
+                    Avanzamento {run.progress}%
+                  </Typography>
+                </Box>
+              </Box>
+            ))}
+          </Stack>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent>
+          <Stack direction={{ xs: 'column', md: 'row' }} justifyContent="space-between" spacing={3}>
+            <Stack direction="row" spacing={1} alignItems="center">
+              <AssessmentRoundedIcon color="primary" />
+              <Box>
+                <Typography variant="h6" fontWeight={600}>
+                  Metriche recenti
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  Latenze e throughput calcolati dalle ultime esecuzioni.
+                </Typography>
+              </Box>
+            </Stack>
+            <Chip label="Aggiorna" clickable color="primary" variant="outlined" />
+          </Stack>
+          <Grid container spacing={3} sx={{ mt: 1 }}>
+            <Grid item xs={12} md={4}>
+              <Box sx={{ p: 3 }}>
+                <Typography variant="subtitle2" color="text.secondary">
+                  Latenza media (ms)
+                </Typography>
+                <Typography variant="h4" fontWeight={700}>
+                  184
+                </Typography>
+              </Box>
+            </Grid>
+            <Grid item xs={12} md={4}>
+              <Box sx={{ p: 3 }}>
+                <Typography variant="subtitle2" color="text.secondary">
+                  Throughput (req/min)
+                </Typography>
+                <Typography variant="h4" fontWeight={700}>
+                  527
+                </Typography>
+              </Box>
+            </Grid>
+            <Grid item xs={12} md={4}>
+              <Box sx={{ p: 3 }}>
+                <Typography variant="subtitle2" color="text.secondary">
+                  Errori ultimi 60 minuti
+                </Typography>
+                <Typography variant="h4" fontWeight={700}>
+                  0
+                </Typography>
+              </Box>
+            </Grid>
+          </Grid>
+        </CardContent>
+      </Card>
+    </Stack>
+  );
+}
+
+export default Dashboard;

--- a/webapp/src/pages/Projects.tsx
+++ b/webapp/src/pages/Projects.tsx
@@ -1,0 +1,113 @@
+import FolderOpenRoundedIcon from '@mui/icons-material/FolderOpenRounded';
+import LaunchRoundedIcon from '@mui/icons-material/LaunchRounded';
+import MoreVertRoundedIcon from '@mui/icons-material/MoreVertRounded';
+import SearchRoundedIcon from '@mui/icons-material/SearchRounded';
+import {
+  Box,
+  Card,
+  CardActions,
+  CardContent,
+  Chip,
+  Grid,
+  IconButton,
+  InputAdornment,
+  Stack,
+  TextField,
+  Typography
+} from '@mui/material';
+
+const projects = [
+  {
+    id: 'proj-1',
+    name: 'Linea di produzione 4.0',
+    description: 'Scenario ibrido con orchestrazione RabbitMQ e analisi REST.',
+    updatedAt: 'Aggiornato 2h fa',
+    tags: ['RabbitMQ', 'Analytics']
+  },
+  {
+    id: 'proj-2',
+    name: 'Robotica collaborativa',
+    description: 'Simulazione streaming in tempo reale per controlli robotici.',
+    updatedAt: 'Aggiornato ieri',
+    tags: ['Streaming', 'MQTT']
+  },
+  {
+    id: 'proj-3',
+    name: 'Fonderia predittiva',
+    description: 'Digital twin che sfrutta REST per la telemetria e RabbitMQ per le code.',
+    updatedAt: 'Aggiornato 3 giorni fa',
+    tags: ['REST', 'RabbitMQ', 'Analytics']
+  }
+];
+
+function Projects() {
+  return (
+    <Stack spacing={4}>
+      <Box>
+        <Typography variant="h4" fontWeight={700} gutterBottom>
+          Progetti Simulation Bridge
+        </Typography>
+        <Typography variant="body1" color="text.secondary">
+          Gestisci template, ambienti di test e scenari condivisi con il tuo team.
+        </Typography>
+      </Box>
+
+      <TextField
+        placeholder="Cerca progetti, protocolli o owner"
+        fullWidth
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <SearchRoundedIcon color="action" />
+            </InputAdornment>
+          )
+        }}
+      />
+
+      <Grid container spacing={3}>
+        {projects.map((project) => (
+          <Grid item xs={12} md={4} key={project.id}>
+            <Card sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+              <CardContent sx={{ flexGrow: 1 }}>
+                <Stack direction="row" justifyContent="space-between" alignItems="flex-start">
+                  <Stack direction="row" spacing={1} alignItems="center">
+                    <FolderOpenRoundedIcon color="primary" />
+                    <Typography variant="h6" fontWeight={600}>
+                      {project.name}
+                    </Typography>
+                  </Stack>
+                  <IconButton size="small">
+                    <MoreVertRoundedIcon fontSize="small" />
+                  </IconButton>
+                </Stack>
+                <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+                  {project.description}
+                </Typography>
+                <Stack direction="row" spacing={1} sx={{ mt: 2, flexWrap: 'wrap' }}>
+                  {project.tags.map((tag) => (
+                    <Chip key={tag} label={tag} size="small" color="primary" variant="outlined" />
+                  ))}
+                </Stack>
+              </CardContent>
+              <CardActions sx={{ justifyContent: 'space-between', px: 3, pb: 3 }}>
+                <Typography variant="caption" color="text.secondary">
+                  {project.updatedAt}
+                </Typography>
+                <Chip
+                  component="a"
+                  href="#"
+                  clickable
+                  color="primary"
+                  icon={<LaunchRoundedIcon />}
+                  label="Apri workspace"
+                />
+              </CardActions>
+            </Card>
+          </Grid>
+        ))}
+      </Grid>
+    </Stack>
+  );
+}
+
+export default Projects;

--- a/webapp/src/pages/Streaming.tsx
+++ b/webapp/src/pages/Streaming.tsx
@@ -1,0 +1,140 @@
+import CastRoundedIcon from '@mui/icons-material/CastRounded';
+import RefreshRoundedIcon from '@mui/icons-material/RefreshRounded';
+import SensorsRoundedIcon from '@mui/icons-material/SensorsRounded';
+import WarningRoundedIcon from '@mui/icons-material/WarningRounded';
+import {
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  Divider,
+  Grid,
+  LinearProgress,
+  Stack,
+  Switch,
+  Typography
+} from '@mui/material';
+
+const streams = [
+  {
+    id: 'stream-1',
+    name: 'Linea 4.0 Robotica',
+    protocol: 'MQTT',
+    rate: '120 msg/min',
+    health: 'Buono',
+    latency: 210,
+    active: true
+  },
+  {
+    id: 'stream-2',
+    name: 'Magazzino automatico',
+    protocol: 'RabbitMQ',
+    rate: '95 msg/min',
+    health: 'Attenzione',
+    latency: 310,
+    active: true
+  },
+  {
+    id: 'stream-3',
+    name: 'Controllo qualità',
+    protocol: 'REST streaming',
+    rate: '45 msg/min',
+    health: 'Offline',
+    latency: 0,
+    active: false
+  }
+];
+
+function Streaming() {
+  return (
+    <Stack spacing={4}>
+      <Box>
+        <Typography variant="h4" fontWeight={700} gutterBottom>
+          Streaming e Telemetria
+        </Typography>
+        <Typography variant="body1" color="text.secondary">
+          Monitora i canali di streaming gestiti dal bridge e agisci in tempo reale.
+        </Typography>
+      </Box>
+
+      <Card>
+        <CardContent>
+          <Stack direction={{ xs: 'column', md: 'row' }} justifyContent="space-between" alignItems={{ md: 'center' }}>
+            <Stack direction="row" spacing={1} alignItems="center">
+              <SensorsRoundedIcon color="primary" />
+              <Box>
+                <Typography variant="h6" fontWeight={600}>
+                  Stato generatore streaming
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  Abilita o disabilita l&apos;invio di aggiornamenti live ai client connessi.
+                </Typography>
+              </Box>
+            </Stack>
+            <Stack direction="row" spacing={2} alignItems="center">
+              <Typography variant="subtitle2">Streaming globale</Typography>
+              <Switch defaultChecked />
+              <Button startIcon={<RefreshRoundedIcon />} variant="outlined">
+                Resetta connessioni
+              </Button>
+            </Stack>
+          </Stack>
+        </CardContent>
+      </Card>
+
+      <Grid container spacing={3}>
+        {streams.map((stream) => (
+          <Grid item xs={12} md={4} key={stream.id}>
+            <Card>
+              <CardContent>
+                <Stack direction="row" justifyContent="space-between" alignItems="flex-start">
+                  <Stack>
+                    <Typography variant="h6" fontWeight={600}>
+                      {stream.name}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary">
+                      {stream.protocol}
+                    </Typography>
+                  </Stack>
+                  <Chip
+                    label={stream.health}
+                    color={stream.health === 'Buono' ? 'success' : stream.health === 'Offline' ? 'default' : 'warning'}
+                    icon={stream.health === 'Attenzione' ? <WarningRoundedIcon /> : undefined}
+                  />
+                </Stack>
+                <Divider sx={{ my: 2 }} />
+                <Typography variant="subtitle2" color="text.secondary">
+                  Frequenza
+                </Typography>
+                <Typography variant="body1" fontWeight={600}>
+                  {stream.rate}
+                </Typography>
+                <Typography variant="subtitle2" color="text.secondary" sx={{ mt: 2 }}>
+                  Latenza media
+                </Typography>
+                <LinearProgress
+                  variant="determinate"
+                  value={Math.min(stream.latency / 4, 100)}
+                  color={stream.latency > 280 ? 'error' : stream.latency > 220 ? 'warning' : 'primary'}
+                  sx={{ height: 10, borderRadius: 5 }}
+                />
+                <Typography variant="caption" color="text.secondary">
+                  {stream.latency ? `${stream.latency} ms` : 'Offline'}
+                </Typography>
+                <Stack direction="row" spacing={1} sx={{ mt: 2 }}>
+                  <Chip label={stream.active ? 'Attivo' : 'Disabilitato'} color={stream.active ? 'primary' : 'default'} />
+                  <Button size="small" variant="text" endIcon={<CastRoundedIcon />}>
+                    Connetti viewer
+                  </Button>
+                </Stack>
+              </CardContent>
+            </Card>
+          </Grid>
+        ))}
+      </Grid>
+    </Stack>
+  );
+}
+
+export default Streaming;

--- a/webapp/src/styles/global.css
+++ b/webapp/src/styles/global.css
@@ -1,0 +1,19 @@
+:root {
+  color-scheme: light;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #f5f7fb;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}

--- a/webapp/src/vite-env.d.ts
+++ b/webapp/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/webapp/tsconfig.json
+++ b/webapp/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/webapp/tsconfig.node.json
+++ b/webapp/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    host: '0.0.0.0'
+  }
+});


### PR DESCRIPTION
## Summary
- add a Vite-based React + TypeScript webapp that exposes Simulation Bridge features through a modern UI
- implement dashboard, configuration editor, project management, automations, collaboration, and streaming monitoring views using Material UI components
- document project structure and scripts for installing, building, and linting the webapp

## Testing
- not run (Node dependencies not installed in CI environment)

------
https://chatgpt.com/codex/tasks/task_e_68de41b21e8883339e2c1af89f051761