### PR TITLE
Integrate performance monitoring into AnyLogic agent flows

### DIFF
--- a/agents/anylogic/anylogic_agent/config/config.yaml.template
+++ b/agents/anylogic/anylogic_agent/config/config.yaml.template
@@ -31,6 +31,11 @@ udp:
   output_port: 9876
   input_port: 9877
 
+performance:
+  enabled: false # Enable/disable performance monitoring
+  log_dir: performance_logs # Directory where performance logs will be stored
+  log_filename: performance_metrics.csv # Name of the CSV file for performance metrics
+
 response_templates:
   success:
     status: success

--- a/agents/anylogic/anylogic_agent/src/core/UDPlistener.py
+++ b/agents/anylogic/anylogic_agent/src/core/UDPlistener.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Dict, Optional
 from ..comm.rabbitmq.rabbitmq_manager import RabbitMQManager
 from ..utils.create_response import create_response
 from ..utils.logger import get_logger
+from ..utils.performance_monitor import PerformanceMonitor
 
 logger = get_logger()
 
@@ -149,7 +150,9 @@ class Listener:
             )
             return
 
-        if not success:
+        if success:
+            PerformanceMonitor().record_result_sent()
+        else:
             logger.error(
                 "Failed to send streaming result for %s (request %s)",
                 self.sim_file,
@@ -180,11 +183,14 @@ class Listener:
         return False
 
     def _handle_completion(self, output: Dict[str, Any]) -> None:
+        perf_monitor = PerformanceMonitor()
+
         data_payload = output.get('data', {}) if isinstance(
             output.get('data'), dict) else {}
         metadata = output.get('metadata') or output.get('simulation_info') or {}
 
         success = False
+        perf_monitor.record_simulation_complete()
         if self._ensure_broker_connected():
             try:
                 response = create_response(
@@ -215,6 +221,7 @@ class Listener:
             )
 
         if success:
+            perf_monitor.record_result_sent()
             logger.info(
                 "Sent completion result for %s (request %s)",
                 self.sim_file,
@@ -226,6 +233,9 @@ class Listener:
                 self.sim_file,
                 self.request_id,
             )
+
+        perf_monitor.record_matlab_stop()
+        perf_monitor.complete_operation()
 
         if self._on_complete:
             try:

--- a/agents/anylogic/anylogic_agent/src/core/agent.py
+++ b/agents/anylogic/anylogic_agent/src/core/agent.py
@@ -10,6 +10,7 @@ from .streaming import stop_all_streaming_sessions
 from ..interfaces.config_manager import IConfigManager
 from ..utils.config_manager import ConfigManager
 from ..utils.logger import get_logger
+from ..utils.performance_monitor import PerformanceMonitor
 from ..comm.connect import Connect
 
 # Configure logger
@@ -42,6 +43,9 @@ class AnylogicAgent:
         # Load configuration
         self.config_manager: IConfigManager = ConfigManager(config_path)
         self.config: Dict[str, Any] = self.config_manager.get_config()
+        # Initialise the performance monitor before setting up communication
+        self.performance_monitor = PerformanceMonitor(self.config)
+
         # Initialize the communication layer
         self.comm = Connect(self.agent_id, self.config, broker_type)
         # Set up the communication infrastructure

--- a/agents/anylogic/anylogic_agent/src/core/interactive.py
+++ b/agents/anylogic/anylogic_agent/src/core/interactive.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, Optional
 from ..comm.rabbitmq.rabbitmq_manager import RabbitMQManager
 from ..utils.create_response import create_response
 from ..utils.logger import get_logger
+from ..utils.performance_monitor import PerformanceMonitor
 from .UDPwriter import Writer
 from .UDPlistener import Listener
 
@@ -57,6 +58,9 @@ def handle_interactive_simulation(
     response_templates: Dict[str, Any],
 ) -> None:
     """Start writer and listener to interactively send and receive messages with AnyLogic simulation."""
+    perf_monitor = PerformanceMonitor()
+    operation_started = False
+
     data = msg_dict.get('simulation', {}) or {}
     request_id = data.get('request_id')
     sim_file = data.get('file')
@@ -77,7 +81,9 @@ def handle_interactive_simulation(
                 'type': 'invalid_request',
             },
         )
-        rabbitmq_manager.send_result(source, error_response)
+        success = rabbitmq_manager.send_result(source, error_response)
+        if success:
+            perf_monitor.record_result_sent()
         return
 
     with _SESSIONS_LOCK:
@@ -105,8 +111,13 @@ def handle_interactive_simulation(
                 'type': 'missing_file',
             },
         )
-        rabbitmq_manager.send_result(source, error_response)
+        success = rabbitmq_manager.send_result(source, error_response)
+        if success:
+            perf_monitor.record_result_sent()
         return
+
+    perf_monitor.start_operation(request_id)
+    operation_started = True
 
     # Start the Writer (sender)
     writer = Writer(
@@ -144,9 +155,22 @@ def handle_interactive_simulation(
     listener_thread.start()
 
     # Wait for both to be ready
-    if not _wait_for_ready(writer, listener, writer_thread, listener_thread,
-                           source, rabbitmq_manager, sim_file, sim_type,
-                           response_templates, bridge_meta, request_id):
+    if not _wait_for_ready(
+        writer,
+        listener,
+        writer_thread,
+        listener_thread,
+        source,
+        rabbitmq_manager,
+        sim_file,
+        sim_type,
+        response_templates,
+        bridge_meta,
+        request_id,
+        perf_monitor,
+    ):
+        if operation_started:
+            perf_monitor.complete_operation()
         return
 
     with _SESSIONS_LOCK:
@@ -159,6 +183,8 @@ def handle_interactive_simulation(
             sim_file=sim_file,
             file_path=expected_file,
         )
+
+    perf_monitor.record_matlab_start()
 
     status_response = create_response(
         template_type='progress',
@@ -177,7 +203,9 @@ def handle_interactive_simulation(
             'listener_port': listener.output_port,
         },
     )
-    rabbitmq_manager.send_result(source, status_response)
+    success = rabbitmq_manager.send_result(source, status_response)
+    if success:
+        perf_monitor.record_result_sent()
     logger.info(
         "Started interactive writer and listener for %s (request %s) on writer %s:%s, listener %s:%s",
         sim_file,
@@ -211,6 +239,7 @@ def _wait_for_ready(
     response_templates: Dict[str, Any],
     bridge_meta: str,
     request_id: str,
+    perf_monitor: PerformanceMonitor,
 ) -> bool:
     """Wait for writer and listener to be ready. Returns True if successful."""
     if not writer.wait_until_ready(
@@ -231,7 +260,9 @@ def _wait_for_ready(
                 'type': 'start_failure',
             },
         )
-        rabbitmq_manager.send_result(source, error_response)
+        success = rabbitmq_manager.send_result(source, error_response)
+        if success:
+            perf_monitor.record_result_sent()
         return False
     return True
 
@@ -240,6 +271,10 @@ def _build_completion_callback(request_id: str):
     """Return a callback that marks the session identified by *request_id* done."""
 
     def _callback(_: str) -> None:
+        perf_monitor = PerformanceMonitor()
+        perf_monitor.record_simulation_complete()
+        perf_monitor.record_matlab_stop()
+        perf_monitor.complete_operation()
         _complete_interactive_session(request_id)
 
     return _callback
@@ -251,6 +286,7 @@ def stop_interactive_session(request_id: str) -> None:
         session = _ACTIVE_SESSIONS.pop(request_id, None)
     if session:
         session.stop()
+    PerformanceMonitor().complete_operation()
 
 
 def stop_all_interactive_sessions() -> None:
@@ -260,6 +296,7 @@ def stop_all_interactive_sessions() -> None:
         _ACTIVE_SESSIONS.clear()
     for session in sessions:
         session.stop()
+    PerformanceMonitor().complete_operation()
 
 
 def _complete_interactive_session(request_id: str) -> None:
@@ -269,3 +306,4 @@ def _complete_interactive_session(request_id: str) -> None:
     if session and threading.current_thread(
     ) is not session.writer_thread and threading.current_thread() is not session.listener_thread:
         session.stop()
+    PerformanceMonitor().complete_operation()

--- a/agents/anylogic/anylogic_agent/src/core/streaming.py
+++ b/agents/anylogic/anylogic_agent/src/core/streaming.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Optional
 
 from ..utils.create_response import create_response
 from ..utils.logger import get_logger
+from ..utils.performance_monitor import PerformanceMonitor
 from .UDPlistener import Listener
 
 logger = get_logger()
@@ -67,6 +68,9 @@ def handle_streaming_simulation(
     The function only starts a new session when the request identifier is not
     already associated with an active listener.
     """
+    perf_monitor = PerformanceMonitor()
+    operation_started = False
+
     data = msg_dict.get('simulation', {}) or {}
     request_id = data.get('request_id')
     sim_file = data.get('file')
@@ -86,7 +90,9 @@ def handle_streaming_simulation(
                 'type': 'invalid_request',
             },
         )
-        rabbitmq_manager.send_result(source, error_response)
+        success = rabbitmq_manager.send_result(source, error_response)
+        if success:
+            perf_monitor.record_result_sent()
         return
 
     with _SESSIONS_LOCK:
@@ -114,8 +120,13 @@ def handle_streaming_simulation(
                 'type': 'missing_file',
             },
         )
-        rabbitmq_manager.send_result(source, error_response)
+        success = rabbitmq_manager.send_result(source, error_response)
+        if success:
+            perf_monitor.record_result_sent()
         return
+
+    perf_monitor.start_operation(request_id)
+    operation_started = True
 
     listener = Listener(
         config=config,
@@ -148,7 +159,11 @@ def handle_streaming_simulation(
                 'type': 'listener_start_failure',
             },
         )
-        rabbitmq_manager.send_result(source, error_response)
+        success = rabbitmq_manager.send_result(source, error_response)
+        if success:
+            perf_monitor.record_result_sent()
+        if operation_started:
+            perf_monitor.complete_operation()
         return
 
     with _SESSIONS_LOCK:
@@ -159,6 +174,8 @@ def handle_streaming_simulation(
             sim_file=sim_file,
             file_path=expected_file,
         )
+
+    perf_monitor.record_matlab_start()
 
     status_response = create_response(
         template_type='progress',
@@ -175,7 +192,9 @@ def handle_streaming_simulation(
             'output_port': listener.output_port,
         },
     )
-    rabbitmq_manager.send_result(source, status_response)
+    success = rabbitmq_manager.send_result(source, status_response)
+    if success:
+        perf_monitor.record_result_sent()
     logger.info(
         "Started streaming listener for %s (request %s) on %s:%s",
         sim_file,
@@ -189,6 +208,10 @@ def _build_completion_callback(request_id: str):
     """Return a callback that marks the session identified by *request_id* done."""
 
     def _callback(_: str) -> None:
+        perf_monitor = PerformanceMonitor()
+        perf_monitor.record_simulation_complete()
+        perf_monitor.record_matlab_stop()
+        perf_monitor.complete_operation()
         _complete_streaming_session(request_id)
 
     return _callback
@@ -200,6 +223,7 @@ def stop_streaming_session(request_id: str) -> None:
         session = _ACTIVE_SESSIONS.pop(request_id, None)
     if session:
         session.stop()
+    PerformanceMonitor().complete_operation()
 
 
 def stop_all_streaming_sessions() -> None:
@@ -209,6 +233,7 @@ def stop_all_streaming_sessions() -> None:
         _ACTIVE_SESSIONS.clear()
     for session in sessions:
         session.stop()
+    PerformanceMonitor().complete_operation()
 
 
 def _complete_streaming_session(request_id: str) -> None:
@@ -217,3 +242,4 @@ def _complete_streaming_session(request_id: str) -> None:
         session = _ACTIVE_SESSIONS.pop(request_id, None)
     if session and threading.current_thread() is not session.thread:
         session.stop()
+    PerformanceMonitor().complete_operation()

--- a/agents/anylogic/anylogic_agent/src/utils/config_manager.py
+++ b/agents/anylogic/anylogic_agent/src/utils/config_manager.py
@@ -60,6 +60,11 @@ class Config(BaseModel):
     udp_output_port: int = Field(default=9876)
     udp_input_port: int = Field(default=9877)
 
+    # Performance monitoring
+    performance_enabled: bool = Field(default=False)
+    performance_log_dir: str = Field(default="performance_logs")
+    performance_log_filename: str = Field(default="performance_metrics.csv")
+
     # Response templates
     # Success template
     success_status: Literal["success"] = Field(default="success")
@@ -124,6 +129,11 @@ class Config(BaseModel):
                 "host": self.udp_host,
                 "output_port": self.udp_output_port,
                 "input_port": self.udp_input_port
+            },
+            "performance": {
+                "enabled": self.performance_enabled,
+                "log_dir": self.performance_log_dir,
+                "log_filename": self.performance_log_filename
             },
             "response_templates": {
                 "success": {
@@ -193,7 +203,13 @@ class Config(BaseModel):
             flat_config["udp_host"] = udp.get("host", "localhost")
             flat_config["udp_output_port"] = udp.get("output_port", 9876)
             flat_config["udp_input_port"] = udp.get("input_port", 9877)
-        
+
+        if performance := config_dict.get("performance", {}):
+            flat_config["performance_enabled"] = performance.get("enabled", False)
+            flat_config["performance_log_dir"] = performance.get("log_dir", "performance_logs")
+            flat_config["performance_log_filename"] = performance.get(
+                "log_filename", "performance_metrics.csv")
+
         # Extract response_templates section if present
         if templates := config_dict.get("response_templates", {}):
             cls._extract_success_template(templates, flat_config)

--- a/agents/anylogic/anylogic_agent/src/utils/performance_monitor.py
+++ b/agents/anylogic/anylogic_agent/src/utils/performance_monitor.py
@@ -1,0 +1,286 @@
+"""
+Performance monitoring utilities for the AnyLogic agent.
+"""
+from __future__ import annotations
+
+import csv
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import psutil
+
+from ..utils.logger import get_logger
+
+logger = get_logger()
+
+
+@dataclass
+class PerformanceMetrics:
+    """Data class to store performance metrics for a single operation."""
+
+    operation_id: str
+    timestamp: float
+    request_received_time: float
+    matlab_start_time: float
+    matlab_startup_duration: float
+    simulation_duration: float
+    matlab_stop_time: float
+    result_send_time: float
+    cpu_percent: float
+    memory_rss_mb: float
+    total_duration: float
+
+
+class PerformanceMonitor:
+    """Singleton used to collect performance metrics for the AnyLogic agent."""
+
+    _instance: Optional["PerformanceMonitor"] = None
+    _initialized = False
+
+    def __new__(cls, *args, **kwargs):
+        if cls._instance is None:
+            cls._instance = super(PerformanceMonitor, cls).__new__(cls)
+        return cls._instance
+
+    def __init__(self, config: Optional[Dict[str, Any]] = None):
+        """Initialise the performance monitor."""
+
+        if not self._initialized:
+            self.enabled = False
+            self.output_dir = Path("performance_logs")
+            self.current_metrics: Optional[PerformanceMetrics] = None
+            self.metrics_history: List[PerformanceMetrics] = []
+            self.process: Optional[psutil.Process] = None
+            self.csv_path: Optional[Path] = None
+
+            if config:
+                perf_config = config.get("performance", {})
+                self.enabled = perf_config.get("enabled", False)
+                log_dir = perf_config.get("log_dir", "performance_logs")
+                log_filename = perf_config.get(
+                    "log_filename", "performance_metrics.csv"
+                )
+
+                if os.path.isabs(log_dir):
+                    self.output_dir = Path(log_dir)
+                else:
+                    self.output_dir = Path.cwd() / log_dir
+            else:
+                log_filename = "performance_metrics.csv"
+
+            if self.enabled:
+                try:
+                    self.output_dir.mkdir(parents=True, exist_ok=True)
+                    logger.debug(
+                        "Created performance log directory: %s", self.output_dir
+                    )
+
+                    self.process = psutil.Process()
+                    self.csv_path = self.output_dir / log_filename
+
+                    if not self.csv_path.exists():
+                        self._write_csv_headers()
+                        logger.debug(
+                            "Created performance metrics file: %s", self.csv_path
+                        )
+
+                    logger.debug(
+                        "Performance monitoring enabled. Logs will be saved to %s",
+                        self.output_dir,
+                    )
+                except Exception as exc:  # pragma: no cover - defensive
+                    logger.error(
+                        "Failed to initialise performance monitoring: %s", exc
+                    )
+                    self.enabled = False
+            else:
+                logger.debug("Performance monitoring is disabled")
+
+            self._initialized = True
+
+    def _write_csv_headers(self) -> None:
+        """Write CSV headers to the output file."""
+
+        if not self.enabled:
+            return
+
+        try:
+            with open(self.csv_path, "w", newline="", encoding="utf-8") as file:
+                writer = csv.writer(file)
+                writer.writerow(
+                    [
+                        "Operation ID",
+                        "Timestamp",
+                        "Request Received Time",
+                        "MATLAB Start Time",
+                        "MATLAB Startup Duration (s)",
+                        "Simulation Duration (s)",
+                        "MATLAB Stop Time",
+                        "Result Send Time",
+                        "CPU Usage (%)",
+                        "Memory RSS (MB)",
+                        "Total Duration (s)",
+                    ]
+                )
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error("Failed to write CSV headers: %s", exc)
+            self.enabled = False
+
+    def start_operation(self, operation_id: str) -> None:
+        """Start monitoring a new operation."""
+
+        if not self.enabled:
+            return
+
+        if self.process is None:
+            self.process = psutil.Process()
+
+        now = time.time()
+        self.current_metrics = PerformanceMetrics(
+            operation_id=operation_id,
+            timestamp=now,
+            request_received_time=now,
+            matlab_start_time=0.0,
+            matlab_startup_duration=0.0,
+            simulation_duration=0.0,
+            matlab_stop_time=0.0,
+            result_send_time=0.0,
+            cpu_percent=self.process.cpu_percent(),
+            memory_rss_mb=self.process.memory_info().rss / (1024 * 1024),
+            total_duration=0.0,
+        )
+        logger.debug("Started monitoring operation %s", operation_id)
+
+    def record_matlab_start(self) -> None:
+        """Record the start of the AnyLogic model execution."""
+
+        if not self.enabled or not self.current_metrics:
+            return
+
+        self.current_metrics.matlab_start_time = time.time()
+        self._update_system_metrics()
+
+    def record_matlab_startup_complete(self) -> None:
+        """Record the completion of the AnyLogic model startup."""
+
+        if not self.enabled or not self.current_metrics:
+            return
+
+        startup_duration = time.time() - self.current_metrics.matlab_start_time
+        self.current_metrics.matlab_startup_duration = startup_duration
+        self._update_system_metrics()
+        logger.debug("AnyLogic startup duration: %.2fs", startup_duration)
+
+    def record_simulation_complete(self) -> None:
+        """Record the completion of the simulation."""
+
+        if not self.enabled or not self.current_metrics:
+            return
+
+        self.current_metrics.simulation_duration = (
+            time.time()
+            - self.current_metrics.matlab_start_time
+            - self.current_metrics.matlab_startup_duration
+        )
+        self._update_system_metrics()
+
+    def record_matlab_stop(self) -> None:
+        """Record when the AnyLogic execution has stopped."""
+
+        if not self.enabled or not self.current_metrics:
+            return
+
+        self.current_metrics.matlab_stop_time = time.time()
+        self._update_system_metrics()
+
+    def record_result_sent(self) -> None:
+        """Record when results are sent."""
+
+        if not self.enabled or not self.current_metrics:
+            return
+
+        self.current_metrics.result_send_time = time.time()
+        self._update_system_metrics()
+
+    def _update_system_metrics(self) -> None:
+        """Update system resource metrics."""
+
+        if not self.enabled or not self.current_metrics or not self.process:
+            return
+
+        self.current_metrics.cpu_percent = self.process.cpu_percent()
+        self.current_metrics.memory_rss_mb = (
+            self.process.memory_info().rss / (1024 * 1024)
+        )
+
+    def complete_operation(self) -> None:
+        """Complete the current operation and save metrics."""
+
+        if not self.enabled or not self.current_metrics:
+            return
+
+        self.current_metrics.total_duration = (
+            time.time() - self.current_metrics.request_received_time
+        )
+        self.metrics_history.append(self.current_metrics)
+        self._save_metrics_to_csv(self.current_metrics)
+        logger.debug(
+            "Completed operation %s in %.2fs",
+            self.current_metrics.operation_id,
+            self.current_metrics.total_duration,
+        )
+        self.current_metrics = None
+
+    def _save_metrics_to_csv(self, metrics: PerformanceMetrics) -> None:
+        """Persist metrics to CSV."""
+
+        if not self.enabled:
+            return
+
+        with open(self.csv_path, "a", newline="", encoding="utf-8") as file:
+            writer = csv.writer(file)
+            writer.writerow(
+                [
+                    metrics.operation_id,
+                    metrics.timestamp,
+                    metrics.request_received_time,
+                    metrics.matlab_start_time,
+                    metrics.matlab_startup_duration,
+                    metrics.simulation_duration,
+                    metrics.matlab_stop_time,
+                    metrics.result_send_time,
+                    metrics.cpu_percent,
+                    metrics.memory_rss_mb,
+                    metrics.total_duration,
+                ]
+            )
+
+    def get_summary(self) -> Dict[str, float]:
+        """Get a summary of performance metrics across all operations."""
+
+        if not self.enabled or not self.metrics_history:
+            return {}
+
+        startup_times = [
+            metrics.matlab_startup_duration for metrics in self.metrics_history
+        ]
+        simulation_times = [
+            metrics.simulation_duration for metrics in self.metrics_history
+        ]
+        total_times = [metrics.total_duration for metrics in self.metrics_history]
+
+        return {
+            "avg_startup_time": sum(startup_times) / len(startup_times),
+            "min_startup_time": min(startup_times),
+            "max_startup_time": max(startup_times),
+            "avg_simulation_time": sum(simulation_times) / len(simulation_times),
+            "min_simulation_time": min(simulation_times),
+            "max_simulation_time": max(simulation_times),
+            "avg_total_time": sum(total_times) / len(total_times),
+            "min_total_time": min(total_times),
+            "max_total_time": max(total_times),
+            "total_operations": len(self.metrics_history),
+        }


### PR DESCRIPTION
## Summary
- add a reusable performance monitor module for the AnyLogic agent mirroring the MATLAB implementation
- hook performance tracking into streaming and interactive request lifecycles, including error paths and manual stops
- update the UDP listener to record result sends and completion events so metrics are closed consistently

## Testing
- python -m compileall agents/anylogic/anylogic_agent/src

------
https://chatgpt.com/codex/tasks/task_e_690927d87a288333966fe60a62e41e5c